### PR TITLE
use https for distfiles.prefix.bitzolder.nl

### DIFF
--- a/bootstrap-prefix.sh
+++ b/bootstrap-prefix.sh
@@ -2091,8 +2091,8 @@ set_helper_vars() {
 	PORTAGE_TMPDIR=${PORTAGE_TMPDIR:-${ROOT}/var/tmp}
 	DISTFILES_URL=${DISTFILES_URL:-"http://dev.gentoo.org/~grobian/distfiles"}
 	GNU_URL=${GNU_URL:="http://ftp.gnu.org/gnu"}
-	DISTFILES_G_O="http://distfiles.prefix.bitzolder.nl"
-	DISTFILES_PFX="http://distfiles.prefix.bitzolder.nl/prefix"
+	DISTFILES_G_O="https://distfiles.prefix.bitzolder.nl"
+	DISTFILES_PFX="https://distfiles.prefix.bitzolder.nl/prefix"
 	GENTOO_MIRRORS=${GENTOO_MIRRORS:="http://distfiles.gentoo.org"}
 	SNAPSHOT_HOST=$(rapx ${DISTFILES_G_O} http://rsync.prefix.bitzolder.nl)
 	SNAPSHOT_URL=${SNAPSHOT_URL:-"${SNAPSHOT_HOST}/snapshots"}


### PR DESCRIPTION
I ran into this issue:

```
Connecting to distfiles.prefix.bitzolder.nl (distfiles.prefix.bitzolder.nl)|80.101.160.106|:80... connected.
HTTP request sent, awaiting response... 403 Forbidden
2020-07-02 09:03:30 ERROR 403: Forbidden.
...
!!! downloading http://distfiles.prefix.bitzolder.nl/snapshots/portage-latest.tar.bz2 failed!
```

Using `https://` instead fixes it for me...