### PR TITLE
fix determining shell in bootstrap_startscript

### DIFF
--- a/bootstrap-prefix.sh
+++ b/bootstrap-prefix.sh
@@ -586,7 +586,7 @@ bootstrap_tree() {
 }
 
 bootstrap_startscript() {
-	local theshell=${SHELL##*/}
+	local theshell=$(echo "${SHELL##*/}" | cut -f1 -d' ')
 	if [[ ${theshell} == "sh" ]] ; then
 		einfo "sh is a generic shell, using bash instead"
 		theshell="bash"


### PR DESCRIPTION
Take into account that $SHELL may contain something like '/bin/bash --noprofile --norc'

This is probably worth pushing back upstream...