### PR TITLE
Add package set install

### DIFF
--- a/playbooks/roles/compatibility-layer/defaults/main.yml
+++ b/playbooks/roles/compatibility-layer/defaults/main.yml
@@ -4,6 +4,8 @@ custom_overlay_url: https://github.com/EESSI/gentoo-overlay.git
 
 prefix_location: /cvmfs/pilot.eessi-hpc.org/test/gentoo/2020
 
+pkg_set: '@2020'
+
 prefix_packages:
   - dev-lang/tcl
   - dev-lang/lua

--- a/playbooks/roles/compatibility-layer/defaults/main.yml
+++ b/playbooks/roles/compatibility-layer/defaults/main.yml
@@ -4,10 +4,10 @@ custom_overlay_url: https://github.com/EESSI/gentoo-overlay.git
 
 prefix_location: /cvmfs/pilot.eessi-hpc.org/test/gentoo/2020
 
-pkg_set: '@2020'
+package_sets: 
+  - '@2020'
 
 prefix_packages:
   - dev-lang/tcl
   - dev-lang/lua
   - app-admin/Lmod
-

--- a/playbooks/roles/compatibility-layer/tasks/install_packages.yml
+++ b/playbooks/roles/compatibility-layer/tasks/install_packages.yml
@@ -1,8 +1,9 @@
 ---
 - name: Install package set
   portage:
-    package: "{{ pkg_set }}"
+    package: "{{ item }}"
     state: present
+  with_items: "{{ package_sets }}"
   tags:
     - set
 

--- a/playbooks/roles/compatibility-layer/tasks/install_packages.yml
+++ b/playbooks/roles/compatibility-layer/tasks/install_packages.yml
@@ -1,4 +1,12 @@
-- name: Install packages
+---
+- name: Install package set
+  portage:
+    package: "{{ pkg_set }}"
+    state: present
+  tags:
+    - set
+
+- name: Install additional packages
   portage:
     package: "{{ item }}"
     state: present


### PR DESCRIPTION
Use us portage set for installing a stack before installing additional packages.

The set wil be created from https://github.com/EESSI/gentoo-overlay/pull/8