### PR TITLE
Update the bootstrap requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An alternative would be the [NixOS](https://nixos.org/).
 
 ### Prerequisites
 
-The bootstrap process will need a clean environment with a compiler (the system version of gcc will do). It also is very sensitive to 
+The bootstrap process will need a clean environment with C and C++ compilers (the system version of gcc and g++ will do) as well as the `make` command. It also is very sensitive to 
 the environment, so setup a user with unset `CFFLAGS`, `CFLAGS`, `LDFLAGS`, `PKG_CONFIG_PATH` and the always harmful `LD_LIBRARY_PATH` variables.
 
 EESSI provides a Singularity container for this.


### PR DESCRIPTION
I tried the gentoo prefix and I was only able to make it work on a fresh CentOS 8, when I have installed the `gcc`, `gcc-c++` and `make` packages.