### PR TITLE
Update singularity-bootstrap-prefix.def

### DIFF
--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -2,7 +2,7 @@ Bootstrap: docker
 From: centos:8.2.2004
 
 %post
-    dnf install -y gcc gcc-c++ diffutils
+    dnf install -y gcc gcc-c++ make
     chmod 755 /usr/local/bin/bootstrap-prefix.sh
 
 %environment

--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -2,7 +2,7 @@ Bootstrap: docker
 From: centos:8.2.2004
 
 %post
-    dnf install -y gcc gcc-c++ make
+    dnf install -y gcc gcc-c++ make diffutils
     chmod 755 /usr/local/bin/bootstrap-prefix.sh
 
 %environment


### PR DESCRIPTION
The "official" listed requirement for the gentoo prefix are `gcc` and `make`. In practice you also need `gcc-c++`.
