### PR TITLE
Add noninteractive option to README and singularity recipe pulls boot…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or simply:
 ```
 ./bootstrap-prefix.sif
 ```
-or noninteractively, with prefix location in $(EPREFIX) and /scratch mounted in the image:
+or non-interactively, with prefix location in `${EPREFIX}` and `/scratch` mounted in the image:
 ```
 singularity run --bind /scratch:/scratch bootstrap-prefix.sh $(EPREFIX) noninteractive
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ or simply:
 ```
 ./bootstrap-prefix.sif
 ```
+or noninteractively, with prefix location in $(EPREFIX) and /scratch mounted in the image:
+```
+singularity run --bind /scratch:/scratch bootstrap-prefix.sh $(EPREFIX) noninteractive
+```
 
 If you want to run your own version of the bootstrap script, use:
 ```

--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -9,8 +9,6 @@ Stage: spython-base
 # Let's get some specs of the machine that is running this job
 cat /proc/cpuinfo && cat /proc/meminfo && df -h
 
-mkdir /scratch
-
 cd /usr/local/bin
 # Get EESSI or Official bootstrap script
 # wget https://gitweb.gentoo.org/repo/proj/prefix.git/plain/scripts/bootstrap-prefix.sh

--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -5,7 +5,6 @@ Stage: spython-base
 # This container installs Gentoo Prefix non-interactively in ${EPREFIX}.
 
 %post
-# Prepared Ubuntu 16.04
 
 # Let's get some specs of the machine that is running this job
 cat /proc/cpuinfo && cat /proc/meminfo && df -h

--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -1,16 +1,35 @@
 Bootstrap: docker
-From: centos:8.2.2004
+From: awesomebytes/gentoo_prefix_ci_prepare
+Stage: spython-base
+
+# This container installs Gentoo Prefix noninteractively in 
 
 %post
-    dnf install -y gcc gcc-c++ make diffutils
-    chmod 755 /usr/local/bin/bootstrap-prefix.sh
+# Prepared Ubuntu 16.04
+
+# Let's get some specs of the machine that is running this job
+cat /proc/cpuinfo && cat /proc/meminfo && df -h
+
+mkdir /scratch
+
+cd /usr/local/bin
+# Get EESSI or Official bootstrap script
+# wget https://gitweb.gentoo.org/repo/proj/prefix.git/plain/scripts/bootstrap-prefix.sh
+wget https://raw.githubusercontent.com/EESSI/compatibility-layer/master/bootstrap-prefix.sh
+chmod +x bootstrap-prefix.sh
 
 %environment
-    export LC_ALL=C
-    export PATH=/usr/local/bin:$PATH
-
-%files
-    bootstrap-prefix.sh /usr/local/bin
+#   export EPREFIX=/scratch/gentoo
+   export LC_ALL=C
+   export PATH=/usr/local/bin:$PATH
 
 %runscript
-    exec /usr/local/bin/bootstrap-prefix.sh "$@"
+   exec /usr/local/bin/bootstrap-prefix.sh "$@" 
+
+%test
+    grep -q NAME=\"Ubuntu\" /etc/os-release
+    if [ $? -eq 0 ]; then
+        echo "Container base is Ubuntu as expected."
+    else
+        echo "Container base is not Ubuntu."
+    fi

--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -1,6 +1,6 @@
 Bootstrap: docker
 From: awesomebytes/gentoo_prefix_ci_prepare
-Stage: spython-base
+Stage: build-prefix
 
 # This container installs Gentoo Prefix non-interactively in ${EPREFIX}.
 
@@ -16,12 +16,14 @@ wget https://raw.githubusercontent.com/EESSI/compatibility-layer/master/bootstra
 chmod +x bootstrap-prefix.sh
 
 %environment
-#   export EPREFIX=/scratch/gentoo
    export LC_ALL=C
    export PATH=/usr/local/bin:$PATH
-
+   if [ -z "$EPREFIX" ]; then
+      export EPREFIX=$1
+   fi
+      
 %runscript
-   exec /usr/local/bin/bootstrap-prefix.sh "$@" 
+   exec /usr/local/bin/bootstrap-prefix.sh $EPREFIX noninteractive 
 
 %test
     grep -q NAME=\"Ubuntu\" /etc/os-release

--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -2,7 +2,7 @@ Bootstrap: docker
 From: awesomebytes/gentoo_prefix_ci_prepare
 Stage: spython-base
 
-# This container installs Gentoo Prefix noninteractively in 
+# This container installs Gentoo Prefix non-interactively in ${EPREFIX}.
 
 %post
 # Prepared Ubuntu 16.04

--- a/singularity-bootstrap-prefix.def
+++ b/singularity-bootstrap-prefix.def
@@ -6,8 +6,6 @@ Stage: build-prefix
 
 %post
 
-# Let's get some specs of the machine that is running this job
-cat /proc/cpuinfo && cat /proc/meminfo && df -h
 
 cd /usr/local/bin
 # Get EESSI or Official bootstrap script


### PR DESCRIPTION
Added noninteractive and install path options to bootstrap-prefix.sh in the README.
Changed Singularity recipe from CentOS to Ubuntu similar to the docker recipe from awesomeguy.

The recipe pulls the EESSI bootstrap-prefix.sh script from the repository, saving a manual step.