### PR TITLE
More host symlinks for NSS

### DIFF
--- a/scripts/prefix-symlink-host-paths.sh
+++ b/scripts/prefix-symlink-host-paths.sh
@@ -23,15 +23,23 @@ if [[ $EPREFIX != $EXPECTED_START/* ]]; then
     exit 1
 fi
 
-# /etc/passwd: required to ensure local users are known (see https://github.com/EESSI/compatibility-layer/issues/15)
-# /etc/group: required to ensure local user groups are known
-for path in /etc/passwd /etc/group; do
+paths=(
+    "/etc/passwd" # required to ensure local users are known (see https://github.com/EESSI/compatibility-layer/issues/15)
+    "/etc/group" # required to ensure local user groups are known
+    "/etc/nsswitch.conf" # required to ensure name-service information is taken from the right source (e.g. ldap)
+    "/etc/resolv.conf" # required to use the DNS resolver from the host (should be done automatically)
+    "/lib64/libnss_centrifydc.so.2" # required if Centrify is used in nsswitch.conf
+    "/lib64/libnss_ldap.so.2" # required if LDAP is used in nsswitch.conf
+    "/lib64/libnss_sss.so.2" # required if SSSD is used in nsswitch.conf
+)
+
+for path in ${paths[@]}; do
     echo ">> checking $path ..."
     ls -ld ${EPREFIX}$path | grep " -> $path" > /dev/null
     ec=$?
     if [ $ec -ne 0 ]; then
         echo_yellow ">> [CHANGE] ${EPREFIX}$path is *not* a symlink to $path, fixing that..."
-        rm ${EPREFIX}$path
+        rm -f ${EPREFIX}$path
         ln -s $path ${EPREFIX}$path
     else
         echo_green ">> [OK] ${EPREFIX}$path is already a symlink to $path"


### PR DESCRIPTION
Also see #15. This adds some more symlinks that fix NSS: now LDAP, Centrify, SSSD should work (I only tested LDAP myself).

It also adds a `-f` to the rm command, to prevent ugly errors in case the Prefix installation does not have this file itself yet.