### PR TITLE
Disable Python 2 support, use configuration files from overlay

### DIFF
--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -5,7 +5,14 @@
 
 This directory contains an Ansible role (`compatibility_layer`) in the subdirectory `roles` which has
 all functionality for installing the compatibility layer into an existing Gentoo Prefix installation.
-It adds a given overlay to the installation and installs a list of package sets and list of additional packages.
+It performs the following tasks:
+
+ - make symlinks to some host files in order to fix issues with, for instance, user accounts and groups;
+ - add a given overlay to the installation;
+ - use the Portage configuration files from that overlay, if applicable, by making symlinks to them;
+ - install a given list of package sets;
+ - install a given list of additional packages.
+ 
 The playbook `install.yml` will execute this role on a given server. 
 
 ## Configuration
@@ -13,26 +20,30 @@ The playbook `install.yml` will execute this role on a given server.
 Before running the playbook, make sure the following settings are correct, and override them if necessary:
 
 ### Overlay settings
-| Variable | Description | Default value |
+| Variable | Description |
 | --- | --- | --- |
-| custom_overlay_name | Repository name for the custom overlay | eessi |
-| custom_overlay_source | Source of the custom overlay | git |
-| custom_overlay_url | URL to the custom overlay | https://github.com/EESSI/gentoo-overlay.git |
+| custom_overlay_name | Repository name for the custom overlay |
+| custom_overlay_source | Source of the custom overlay |
+| custom_overlay_url | URL to the custom overlay |
 
 ### CVMFS settings
-| Variable | Description | Default value |
+| Variable | Description |
 | --- | --- | --- |
-| cvmfs_start_transaction | Whether a CVMFS transaction should be start at the start | False |
-| cvmfs_publish_transaction | Whether a CVMFS transaction should be published at the end | False |
-| cvmfs_abort_transaction_on_failures | Whether a CVMFS transaction should be aborted on failures | False |
-| cvmfs_repository | Name of your CVMFS repository (used for the transaction) | pilot.eessi-hpc.org |
+| cvmfs_start_transaction | Whether a CVMFS transaction should be start at the start |
+| cvmfs_publish_transaction | Whether a CVMFS transaction should be published at the end |
+| cvmfs_abort_transaction_on_failures | Whether a CVMFS transaction should be aborted on failures |
+| cvmfs_repository | Name of your CVMFS repository (used for the transaction) |
 
 ### Prefix and packages
-| Variable | Description | Default value |
+| Variable | Description |
 | --- | --- | --- |
-| gentoo_prefix_path | Path to the root of your Gentoo Prefix installation | /cvmfs/pilot.eessi-hpc.org/compat/x86_64 |
-| package_sets | List of package sets to be installed | 2020 |
-| prefix_packages | List of additional packages to be installed | - |
+| gentoo_prefix_path | Path to the root of your Gentoo Prefix installation |
+| package_sets | List of package sets to be installed |
+| prefix_packages | List of additional packages to be installed |
+| python_targets | String consisting of [Gentoo Python targets](https://wiki.gentoo.org/wiki/Project:Python/PYTHON_TARGETS) |
+| symlinks_to_host | List of paths that should get a symlink to the corresponding host path |
+
+For the default values, see the [defaults file](roles/compatibility_layer/defaults/main.yml).
 
 ## Running the playbook 
 

--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -7,7 +7,7 @@ This directory contains an Ansible role (`compatibility_layer`) in the subdirect
 all functionality for installing the compatibility layer into an existing Gentoo Prefix installation.
 It performs the following tasks:
 
- - make symlinks to some host files in order to fix issues with, for instance, user accounts and groups;
+ - make symlinks to some host paths in order to fix issues with, for instance, user accounts and groups;
  - add a given overlay to the installation;
  - use the Portage configuration files from that overlay, if applicable, by making symlinks to them;
  - install a given list of package sets;

--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -20,15 +20,16 @@ The playbook `install.yml` will execute this role on a given server.
 Before running the playbook, make sure the following settings are correct, and override them if necessary:
 
 ### Overlay settings
+
 | Variable | Description |
-| --- | --- | --- |
+| --- | --- |
 | custom_overlay_name | Repository name for the custom overlay |
 | custom_overlay_source | Source of the custom overlay |
 | custom_overlay_url | URL to the custom overlay |
 
 ### CVMFS settings
 | Variable | Description |
-| --- | --- | --- |
+| --- | --- |
 | cvmfs_start_transaction | Whether a CVMFS transaction should be start at the start |
 | cvmfs_publish_transaction | Whether a CVMFS transaction should be published at the end |
 | cvmfs_abort_transaction_on_failures | Whether a CVMFS transaction should be aborted on failures |
@@ -36,7 +37,7 @@ Before running the playbook, make sure the following settings are correct, and o
 
 ### Prefix and packages
 | Variable | Description |
-| --- | --- | --- |
+| --- | --- |
 | gentoo_prefix_path | Path to the root of your Gentoo Prefix installation |
 | package_sets | List of package sets to be installed |
 | prefix_packages | List of additional packages to be installed |

--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -17,7 +17,7 @@ The playbook `install.yml` will execute this role on a given server.
 
 ## Configuration
 
-Before running the playbook, make sure the following settings are correct, and override them if necessary:
+Before running the playbook, make sure the following settings are correct, and override them if necessary. For the default values, see the [defaults file](roles/compatibility_layer/defaults/main.yml).
 
 ### Overlay settings
 
@@ -43,8 +43,6 @@ Before running the playbook, make sure the following settings are correct, and o
 | prefix_packages | List of additional packages to be installed |
 | python_targets | String consisting of [Gentoo Python targets](https://wiki.gentoo.org/wiki/Project:Python/PYTHON_TARGETS) |
 | symlinks_to_host | List of paths that should get a symlink to the corresponding host path |
-
-For the default values, see the [defaults file](roles/compatibility_layer/defaults/main.yml).
 
 ## Running the playbook 
 

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -16,6 +16,10 @@ package_sets:
 
 prefix_packages:
 
+# Set this to the same Python version as used during the Gentoo Prefix bootstrap.
+# This ensures that no other Python version gets installed while adding the custom overlay. 
+python_targets: "python3_7"
+
 # List of locations that should get a symlink $EPREFIX/$LOCATION -> $LOCATION.
 # This ensures that things like user/group ids are correct/looked up in the right way in the Prefix environment.
 symlinks_to_host:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
@@ -36,16 +36,17 @@
   portage:
     sync: 'yes'
 
-- name: Make sets directory
-  file:
-    path: "{{ gentoo_prefix_path }}/etc/portage/sets"
-    state: directory
-    mode: '0755'
+- name: Find all files and directories in the etc/portage directory of the overlay
+  find:
+    file_type: any
+    paths: "{{ gentoo_prefix_path }}/var/db/repos/{{ custom_overlay_name }}/etc/portage"
+  register: find_configs
 
-- name: Make symlink to all package set files in the custom overlay
+- name: Make symlinks to the portage settings in the custom overlay
   file:
-    src: "{{ gentoo_prefix_path }}/var/db/repos/{{ custom_overlay_name }}/etc/portage/sets/{{ item }}"
-    dest: "{{ gentoo_prefix_path }}/etc/portage/sets/{{ item }}"
+    src: "{{ item.path }}"
+    dest: "{{ gentoo_prefix_path }}/etc/portage/{{ item.path | basename }}"
     state: link
+    force: yes
   with_items:
-    "{{ package_sets }}"
+    "{{ find_configs.files }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -24,6 +24,10 @@
   - include_tasks: create_host_symlinks.yml
 
   - include_tasks: add_overlay.yml
+    args:
+      apply:
+        environment:
+          PYTHON_TARGETS: " {{ python_targets }} "
 
   - include_tasks: install_packages.yml
 


### PR DESCRIPTION
Removed the default values from the README, since this gets outdated quickly. They can be easily found in the defaults file.