### PR TITLE
Update Ansible role defaults for 2020.10 pilot

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -9,13 +9,13 @@ cvmfs_publish_transaction: False
 cvmfs_abort_transaction_on_failures: False
 cvmfs_repository: pilot.eessi-hpc.org
 
-gentoo_prefix_path: /cvmfs/pilot.eessi-hpc.org/2020.09/compat/x86_64
+gentoo_prefix_path: /cvmfs/pilot.eessi-hpc.org/2020.10/compat/x86_64
 
 prefix_locales:
   - en_US.UTF-8 UTF-8
 
 package_sets: 
-  - 2020.08
+  - "2020.10"
 
 prefix_packages:
 


### PR DESCRIPTION
Also fixes an issue with the item in the `package_sets` list: they have to be quoted to prevent them from being interpreted as numbers. This hasn't caused any issues with previous pilots, but in this case `2020.10` would be converted to `2020.1`...