### PR TITLE
Install arch-specific set

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -15,8 +15,8 @@ prefix_locales:
   - en_US.UTF-8 UTF-8
 
 package_sets: 
-  - "{{ eessi_version }}"
-  - "{{ eessi_version }}-{{ eessi_host_arch }}"
+  - "eessi-{{ eessi_version }}"
+  - "eessi-{{ eessi_version }}-{{ eessi_host_os}}-{{ eessi_host_arch }}"
 
 prefix_packages:
 

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -15,7 +15,8 @@ prefix_locales:
   - en_US.UTF-8 UTF-8
 
 package_sets: 
-  - "2020.10"
+  - "2020.11"
+  - "2020.11-{{ eessi_host_arch }}"
 
 prefix_packages:
 

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -15,8 +15,8 @@ prefix_locales:
   - en_US.UTF-8 UTF-8
 
 package_sets: 
-  - "2020.11"
-  - "2020.11-{{ eessi_host_arch }}"
+  - "{{ eessi_version }}"
+  - "{{ eessi_version }}-{{ eessi_host_arch }}"
 
 prefix_packages:
 

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -14,6 +14,7 @@ gentoo_prefix_path: /cvmfs/pilot.eessi-hpc.org/2020.10/compat/x86_64
 prefix_locales:
   - en_US.UTF-8 UTF-8
 
+# By default, we install the base set and an architecture-specific set
 package_sets: 
   - "eessi-{{ eessi_version }}"
   - "eessi-{{ eessi_version }}-{{ eessi_host_os}}-{{ eessi_host_arch }}"


### PR DESCRIPTION
WIP, as I still need to test it, and it depends on PR #57 (or you have to set `eessi_host_arch` manually for now).