### PR TITLE
bump EESSI version to 2020.12 in playbook

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -1,6 +1,6 @@
 # Defaults file for the compatibility layer role.
 ---
-eessi_version: "2020.11"
+eessi_version: "2020.12"
 
 custom_overlay_name: eessi
 custom_overlay_source: git


### PR DESCRIPTION
We're skipping 2020.11, so let's bump to 2020.12 in the playbook...