### PR TITLE
bump to Python 3.8 in Gentoo Prefix

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -16,7 +16,7 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/{{ eessi_version }}/compat/{{ 
 # How to build the prefix
 prefix_snapshot_url: http://cvmfs-s0.eessi-hpc.org/snapshots
 prefix_snapshot: portage-20201126.tar.bz2
-prefix_python_targets: python3_7
+prefix_python_targets: python3_8
 prefix_singularity_command: "singularity run -B {{ gentoo_prefix_path }}:{{ gentoo_prefix_path }}"
 prefix_source: "docker://eessi/bootstrap-prefix:centos8-{{ eessi_host_arch }}"
 prefix_source_options: "{{ gentoo_prefix_path }} noninteractive"


### PR DESCRIPTION
This was missing from #64, hopefully tests will pass again with this...