### PR TITLE
Add checks for existence of the startprefix script

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -62,3 +62,13 @@
   changed_when: True
   tags:
     - build_prefix
+
+- name: "Check if startprefix script has been created"
+  stat:
+    path: "{{ gentoo_prefix_path }}/startprefix"
+  register: startprefix
+
+- name: "Fail if startprefix script has not been created"
+  fail:
+    msg: "The resulting Gentoo Prefix installation does not have a startprefix script. Something went wrong!"
+  when: not startprefix.stat.exists

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -7,11 +7,11 @@
 
 - name: Check if a Prefix installation is found at the specified location
   stat:
-    path: "{{ gentoo_prefix_path }}/usr/bin/emerge"
-  register: emerge
+    path: "{{ gentoo_prefix_path }}/startprefix"
+  register: startprefix
 
 - include_tasks: install_prefix.yml
-  when: not emerge.stat.exists
+  when: not startprefix.stat.exists
 
 - name: Start transaction
   command: "cvmfs_server transaction {{ cvmfs_repository }}"


### PR DESCRIPTION
This checks if `$EPREFIX/startprefix` exists, both before doing the Prefix installation (in this case, the prefix installation step will be skipped), and after doing a Prefix installation (to check if the installation succeeded).

Closes #79.