### PR TITLE
Reinstall glibc in playbook

### DIFF
--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -42,6 +42,7 @@ Before running the playbook, make sure the following settings are correct, and o
 | prefix_snapshot_url | Directory (served over http(s)) containing snapshot files |
 | prefix_snapshot_version | Date (`YYYYMMDD`) of the Portage snapshot file for the Prefix installation |
 | prefix_python_targets | String consisting of [Gentoo Python targets](https://wiki.gentoo.org/wiki/Project:Python/PYTHON_TARGETS) Python targets used for the Prefix installation |
+| prefix_user_defined_trusted_dir | Path to the user defined trusted dir for glibc |
 | prefix_singularity_command | Singularity command for launching the container with the bootstrap script |
 | prefix_source | Singularity container path used for the Prefix installtion |
 | prefix_source_options | Arguments to be passed to the Prefix bootstrap script |

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -19,6 +19,7 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/{{ eessi_version }}/compat/{{ 
 prefix_snapshot_url: http://cvmfs-s0.eessi-hpc.org/snapshots
 prefix_snapshot_version: 20210222
 prefix_python_targets: python3_8
+prefix_user_defined_trusted_dir: /opt/eessi/lib
 prefix_singularity_command: "singularity run -B {{ gentoo_prefix_path }}:{{ gentoo_prefix_path }}"
 prefix_source: "docker://eessi/bootstrap-prefix:centos8-{{ eessi_host_arch }}"
 prefix_source_options: "{{ gentoo_prefix_path }} noninteractive"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
@@ -77,18 +77,3 @@
     force: yes
   with_items:
     "{{ find_configs.results | rejectattr('files', 'equalto', []) | map(attribute='files') | list }}"
-
-- name: Check if glibc has already been (re)installed with the user-defined-trusted-dirs option
-  command: "grep {{ prefix_user_defined_trusted_dir }} {{ gentoo_prefix_path }}/usr/lib64/libc.a"
-  register: glibc_reinstalled
-  when: eessi_host_os == "linux"
-
-- name: Reinstall glibc with the user-defined-trusted-dirs option
-  portage:
-    package: sys-libs/glibc
-    noreplace: no
-    oneshot: yes
-  become: no
-  environment:
-    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
-  when: eessi_host_os == "linux" and glibc_reinstalled.rc != 0

--- a/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
@@ -78,3 +78,17 @@
   with_items:
     "{{ find_configs.results | rejectattr('files', 'equalto', []) | map(attribute='files') | list }}"
 
+- name: Check if glibc has already been (re)installed with the user-defined-trusted-dirs option
+  command: "grep {{ prefix_user_defined_trusted_dir }} {{ gentoo_prefix_path }}/usr/lib64/libc.a"
+  register: glibc_reinstalled
+  when: eessi_host_os == "linux"
+
+- name: Reinstall glibc with the user-defined-trusted-dirs option
+  portage:
+    package: sys-libs/glibc
+    noreplace: no
+    oneshot: yes
+  become: no
+  environment:
+    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
+  when: eessi_host_os == "linux" and glibc_reinstalled.rc != 0

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -1,5 +1,12 @@
 # Install a specified list of sets and packages.
 ---
+- name: Reinstall glibc with the user-defined-trusted-dirs option
+  portage:
+    package: sys-libs/glibc
+    noreplace: no
+    oneshot: yes
+  become: no
+
 - name: Install package set {{ package_sets }}
   portage:
     package: "@{{ item }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -1,7 +1,7 @@
 # Install a specified list of sets and packages.
 ---
 - name: Check if glibc has already been (re)installed with the user-defined-trusted-dirs option
-  shell: "strings {{ gentoo_prefix_path }}/usr/lib64/libc.a"
+  command: "strings {{ gentoo_prefix_path }}/usr/lib64/libc.a"
   register: glibc_reinstalled
   when: eessi_host_os == "linux"
 

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -1,7 +1,7 @@
 # Install a specified list of sets and packages.
 ---
 - name: Check if glibc has already been (re)installed with the user-defined-trusted-dirs option
-  command: "grep {{ prefix_user_defined_trusted_dir }} {{ gentoo_prefix_path }}/usr/lib64/libc.a"
+  shell: "strings {{ gentoo_prefix_path }}/usr/lib64/libc.a | grep {{ prefix_user_defined_trusted_dir }}"
   register: glibc_reinstalled
   when: eessi_host_os == "linux"
   failed_when: glibc_reinstalled.rc >= 2

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -1,10 +1,9 @@
 # Install a specified list of sets and packages.
 ---
 - name: Check if glibc has already been (re)installed with the user-defined-trusted-dirs option
-  shell: "strings {{ gentoo_prefix_path }}/usr/lib64/libc.a | grep {{ prefix_user_defined_trusted_dir }}"
+  shell: "strings {{ gentoo_prefix_path }}/usr/lib64/libc.a"
   register: glibc_reinstalled
   when: eessi_host_os == "linux"
-  failed_when: glibc_reinstalled.rc >= 2
 
 - name: Reinstall glibc with the user-defined-trusted-dirs option
   portage:
@@ -14,7 +13,7 @@
   become: no
   environment:
     EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
-  when: eessi_host_os == "linux" and glibc_reinstalled.rc != 0
+  when: eessi_host_os == "linux" and glibc_reinstalled.stdout | regex_search("^" + prefix_user_defined_trusted_dir + "/?$")
 
 - name: Install package set {{ package_sets }}
   portage:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -6,6 +6,7 @@
     noreplace: no
     oneshot: yes
   become: no
+  when: eessi_host_os == "linux"
 
 - name: Install package set {{ package_sets }}
   portage:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -4,6 +4,7 @@
   command: "grep {{ prefix_user_defined_trusted_dir }} {{ gentoo_prefix_path }}/usr/lib64/libc.a"
   register: glibc_reinstalled
   when: eessi_host_os == "linux"
+  failed_when: glibc_reinstalled.rc >= 2
 
 - name: Reinstall glibc with the user-defined-trusted-dirs option
   portage:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -1,5 +1,20 @@
 # Install a specified list of sets and packages.
 ---
+- name: Check if glibc has already been (re)installed with the user-defined-trusted-dirs option
+  command: "grep {{ prefix_user_defined_trusted_dir }} {{ gentoo_prefix_path }}/usr/lib64/libc.a"
+  register: glibc_reinstalled
+  when: eessi_host_os == "linux"
+
+- name: Reinstall glibc with the user-defined-trusted-dirs option
+  portage:
+    package: sys-libs/glibc
+    noreplace: no
+    oneshot: yes
+  become: no
+  environment:
+    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
+  when: eessi_host_os == "linux" and glibc_reinstalled.rc != 0
+
 - name: Install package set {{ package_sets }}
   portage:
     package: "@{{ item }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -1,13 +1,5 @@
 # Install a specified list of sets and packages.
 ---
-- name: Reinstall glibc with the user-defined-trusted-dirs option
-  portage:
-    package: sys-libs/glibc
-    noreplace: no
-    oneshot: yes
-  become: no
-  when: eessi_host_os == "linux"
-
 - name: Install package set {{ package_sets }}
   portage:
     package: "@{{ item }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -13,7 +13,7 @@
     oneshot: yes
   become: no
   environment:
-    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
+    EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
   when: eessi_host_os == "linux" and glibc_reinstalled.rc != 0
 
 - name: Install package set {{ package_sets }}

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -20,8 +20,6 @@
 - block:
   - include_tasks: prefix_configuration.yml
 
-  - include_tasks: create_host_symlinks.yml
-
   - include_tasks: add_overlay.yml
     args:
       apply:
@@ -30,6 +28,8 @@
           PYTHON_TARGETS: "{{ prefix_python_targets }}"
 
   - include_tasks: install_packages.yml
+
+  - include_tasks: create_host_symlinks.yml
 
   - name: Publish transaction
     command: "cvmfs_server publish {{ cvmfs_repository }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
@@ -9,3 +9,13 @@
     state: present
   with_items: "{{ prefix_locales }}"
   notify: Generate locales
+
+- name: Reinstall glibc with the user-defined-trusted-dirs option
+  portage:
+    package: sys-libs/glibc
+    noreplace: no
+    oneshot: yes
+  become: no
+  environment:
+    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
+  when: eessi_host_os == "linux"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
@@ -9,13 +9,3 @@
     state: present
   with_items: "{{ prefix_locales }}"
   notify: Generate locales
-
-- name: Reinstall glibc with the user-defined-trusted-dirs option
-  portage:
-    package: sys-libs/glibc
-    noreplace: no
-    oneshot: yes
-  become: no
-  environment:
-    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dir }}"
-  when: eessi_host_os == "linux"


### PR DESCRIPTION
Fixes https://github.com/EESSI/gentoo-overlay/issues/7.

I've added this as a separate step in `install_packages.yml`, as it requires `noreplace: no`, and I don't want to reinstall our entire set every time we (re)run this playbook. Also setting `oneshot: yes` to prevent `glibc` from being added to the `world` file.

We need another PR in https://github.com/EESSI/gentoo-overlay to remove `glibc` from the set.