### PR TITLE
Make glibc trusted dirs reference a CVMFS variable symlink

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -21,7 +21,7 @@ prefix_snapshot_url: http://cvmfs-s0.eessi-hpc.org/snapshots
 prefix_snapshot_version: 20210322
 prefix_python_targets: python3_8
 prefix_user_defined_trusted_dirs:
-  - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}"
+  - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"
 prefix_singularity_command: "singularity run -B {{ gentoo_prefix_path }}:{{ gentoo_prefix_path }}"
 prefix_source: "docker://eessi/bootstrap-prefix:centos8-{{ eessi_host_arch }}"
 prefix_source_options: "{{ gentoo_prefix_path }} noninteractive"

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -21,8 +21,7 @@ prefix_snapshot_url: http://cvmfs-s0.eessi-hpc.org/snapshots
 prefix_snapshot_version: 20210322
 prefix_python_targets: python3_8
 prefix_user_defined_trusted_dirs:
-  - "/opt/eessi/{{ eessi_version }}/lib"
-  - "/opt/eessi/lib"
+  - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}"
 prefix_singularity_command: "singularity run -B {{ gentoo_prefix_path }}:{{ gentoo_prefix_path }}"
 prefix_source: "docker://eessi/bootstrap-prefix:centos8-{{ eessi_host_arch }}"
 prefix_source_options: "{{ gentoo_prefix_path }} noninteractive"


### PR DESCRIPTION
`/cvmfs/{{ cvmfs_repository }}/host_injections` is a variable symlink with a structure that can be controlled by a (yet to be created) script.