### PR TITLE
Create glibc env file

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_packages.yml
@@ -1,27 +1,5 @@
 # Install a specified list of sets and packages.
 ---
-- name: Find all strings in libc library
-  command: "strings {{ gentoo_prefix_path }}/usr/lib64/libc.a"
-  register: libc_strings
-  when: eessi_host_os == "linux"
-
-- name: Find user defined trusted dirs in libc strings output
-  set_fact: match='{{ libc_strings.stdout | regex_search("\n" + item + "/?\n") | default('', True) | string | length>0 }}'
-  with_items: "{{ prefix_user_defined_trusted_dirs }}"
-  register: trusted_dirs_in_libc
-
-- name: (Re)install glibc with the user-defined-trusted-dirs option
-  portage:
-    package: sys-libs/glibc
-    noreplace: no
-    oneshot: yes
-  become: no
-  environment:
-    EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
-  when:
-    - eessi_host_os == "linux"
-    - trusted_dirs_in_libc.results | selectattr('ansible_facts.match', 'equalto', False) | list | length>0
-
 - name: Install package set {{ package_sets }}
   portage:
     package: "@{{ item }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -27,6 +27,8 @@
         environment:
           PYTHON_TARGETS: "{{ prefix_python_targets }}"
 
+  - include_tasks: set_glibc_trusted_dirs.yml
+
   - include_tasks: install_packages.yml
 
   - include_tasks: create_host_symlinks.yml

--- a/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
@@ -1,0 +1,44 @@
+# Make sure that glibc is always compiled with a user-defined-trusted-dirs option
+---
+- name: Find all strings in libc library
+  command: "strings {{ gentoo_prefix_path }}/usr/lib64/libc.a"
+  register: libc_strings
+  when: eessi_host_os == "linux"
+
+- name: Find user defined trusted dirs in libc strings output
+  set_fact: match='{{ libc_strings.stdout | regex_search("\n" + item + "/?\n") | default('', True) | string | length>0 }}'
+  with_items: "{{ prefix_user_defined_trusted_dirs }}"
+  register: trusted_dirs_in_libc
+
+- name: (Re)install glibc with the user-defined-trusted-dirs option
+  portage:
+    package: sys-libs/glibc
+    noreplace: no
+    oneshot: yes
+  become: no
+  environment:
+    EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
+  when:
+    - eessi_host_os == "linux"
+    - trusted_dirs_in_libc.results | selectattr('ansible_facts.match', 'equalto', False) | list | length>0
+
+- name: Create portage env directory
+  file:
+    path: "{{ gentoo_prefix_path }}/etc/portage/env"
+    state: directory
+    mode: '0755'
+
+- name: Add env file for glibc to make sure the user-defined-trusted-dirs is always used
+  copy:
+    dest: "{{ gentoo_prefix_path }}/etc/portage/env/glibc-user-defined-trusted-dirs.conf"
+    content: |
+      EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
+
+- name: Add glibc env file to package.env
+  lineinfile:
+    path: "{{ gentoo_prefix_path }}/etc/portage/package.env"
+    create: yes
+    mode: 0644
+    line: sys-libs/glibc glibc-user-defined-trusted-dirs.conf
+    state: present
+

--- a/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
@@ -17,7 +17,7 @@
     oneshot: yes
   become: no
   environment:
-    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
+    EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
   when:
     - eessi_host_os == "linux"
     - trusted_dirs_in_libc.results | selectattr('ansible_facts.match', 'equalto', False) | list | length>0
@@ -33,7 +33,7 @@
     dest: "{{ gentoo_prefix_path }}/etc/portage/env/glibc-user-defined-trusted-dirs.conf"
     mode: 0644
     content: |
-      EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
+      EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
 
 - name: Add glibc env file to package.env
   lineinfile:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
@@ -31,6 +31,7 @@
 - name: Add env file for glibc to make sure the user-defined-trusted-dirs is always used
   copy:
     dest: "{{ gentoo_prefix_path }}/etc/portage/env/glibc-user-defined-trusted-dirs.conf"
+    mode: 0644
     content: |
       EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
 

--- a/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
@@ -17,7 +17,7 @@
     oneshot: yes
   become: no
   environment:
-    EXTRA_EMAKE: "user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
+    EXTRA_EMAKE="user-defined-trusted-dirs={{ prefix_user_defined_trusted_dirs | join(':') }}"
   when:
     - eessi_host_os == "linux"
     - trusted_dirs_in_libc.results | selectattr('ansible_facts.match', 'equalto', False) | list | length>0

--- a/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/set_glibc_trusted_dirs.yml
@@ -26,7 +26,7 @@
   file:
     path: "{{ gentoo_prefix_path }}/etc/portage/env"
     state: directory
-    mode: '0755'
+    mode: 0755
 
 - name: Add env file for glibc to make sure the user-defined-trusted-dirs is always used
   copy:

--- a/test/compat_layer.py
+++ b/test/compat_layer.py
@@ -182,3 +182,28 @@ class SymlinksToHostFilesTest(RunInGentooPrefixTest):
             sn.assert_eq(self.exit_code, 0),
             sn.assert_found(f'\n/{self.symlink_to_host}\n', self.stdout),
         ])
+
+@rfm.simple_test
+class GlibcEnvFileTest(RunInGentooPrefixTest):
+    def __init__(self):
+        # the glibc env file was added in 2021.06
+        self.skip_if(self.eessi_version == '2021.03')
+
+        super().__init__()
+        self.descr = 'Verify that the env file for sys-libs/glibc was created and is picked up by emerge.'
+        self.command = 'equery has --package glibc EXTRA_EMAKE'
+
+        trusted_dir = os.path.join(
+            self.eessi_repo_dir,
+            'host_injections',
+            self.eessi_version,
+            'compat',
+            self.eessi_os,
+            self.eessi_arch,
+            'lib'
+        )
+
+        self.sanity_patterns = sn.assert_found(
+            f'user-defined-trusted-dirs={trusted_dir}',
+            self.stdout
+        )


### PR DESCRIPTION
Closes #104 by adding some steps to the playbook that create an env file for glibc. This ensures that the `user-defined-trusted-dirs` is also used when glibc gets recompiled later on, e.g. when performing security updates.

As there were quite a few glibc steps in the task `install_packages.yml`, I've moved these to a separate task `set_glibc_trusted_dirs.yml`.