### PR TITLE
Updates for pilot 2021.06

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -19,7 +19,6 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/{{ eessi_version }}/compat/{{ 
 prefix_required_space: 15 GB
 prefix_snapshot_url: https://eessi-gentoo-snapshot.s3-eu-west-1.amazonaws.com
 prefix_snapshot_version: 20210607
-#prefix_python_targets: python3_9
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"
 prefix_singularity_command: "singularity run -B {{ gentoo_prefix_path }}:{{ gentoo_prefix_path }}"
@@ -27,7 +26,6 @@ prefix_source: "docker://eessi/bootstrap-prefix:centos8-{{ eessi_host_arch }}"
 prefix_source_options: "{{ gentoo_prefix_path }} noninteractive"
 prefix_install: >-
     SINGULARITYENV_USE_CPU_CORES={{ ansible_processor_vcpus }}
-    #SINGULARITYENV_PYTHON_TARGETS="{{ prefix_python_targets }}"
     SINGULARITYENV_CUSTOM_SNAPSHOT_URL="{{ prefix_snapshot_url }}"
     SINGULARITYENV_CUSTOM_SNAPSHOT_VERSION="{{ prefix_snapshot_version }}"
     {{ prefix_singularity_command }} {{ prefix_source }} {{ prefix_source_options }}

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -1,6 +1,6 @@
 # Defaults file for the compatibility layer role.
 ---
-eessi_version: "2021.03"
+eessi_version: "2021.06"
 
 custom_overlays:
   - name: eessi

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -19,7 +19,7 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/{{ eessi_version }}/compat/{{ 
 prefix_required_space: 15 GB
 prefix_snapshot_url: https://eessi-gentoo-snapshot.s3-eu-west-1.amazonaws.com
 prefix_snapshot_version: 20210607
-prefix_python_targets: python3_8
+prefix_python_targets: python3_9
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"
 prefix_singularity_command: "singularity run -B {{ gentoo_prefix_path }}:{{ gentoo_prefix_path }}"

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -17,8 +17,8 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/{{ eessi_version }}/compat/{{ 
 
 # How to build the prefix
 prefix_required_space: 15 GB
-prefix_snapshot_url: http://cvmfs-s0.eessi-hpc.org/snapshots
-prefix_snapshot_version: 20210322
+prefix_snapshot_url: https://eessi-gentoo-snapshot.s3-eu-west-1.amazonaws.com
+prefix_snapshot_version: 20210607
 prefix_python_targets: python3_8
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -19,7 +19,7 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/{{ eessi_version }}/compat/{{ 
 prefix_required_space: 15 GB
 prefix_snapshot_url: https://eessi-gentoo-snapshot.s3-eu-west-1.amazonaws.com
 prefix_snapshot_version: 20210607
-prefix_python_targets: python3_9
+#prefix_python_targets: python3_9
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"
 prefix_singularity_command: "singularity run -B {{ gentoo_prefix_path }}:{{ gentoo_prefix_path }}"
@@ -27,7 +27,7 @@ prefix_source: "docker://eessi/bootstrap-prefix:centos8-{{ eessi_host_arch }}"
 prefix_source_options: "{{ gentoo_prefix_path }} noninteractive"
 prefix_install: >-
     SINGULARITYENV_USE_CPU_CORES={{ ansible_processor_vcpus }}
-    SINGULARITYENV_PYTHON_TARGETS="{{ prefix_python_targets }}"
+    #SINGULARITYENV_PYTHON_TARGETS="{{ prefix_python_targets }}"
     SINGULARITYENV_CUSTOM_SNAPSHOT_URL="{{ prefix_snapshot_url }}"
     SINGULARITYENV_CUSTOM_SNAPSHOT_VERSION="{{ prefix_snapshot_version }}"
     {{ prefix_singularity_command }} {{ prefix_source }} {{ prefix_source_options }}

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -24,8 +24,6 @@
     args:
       apply:
         become: False
-        #environment:
-        #  PYTHON_TARGETS: "{{ prefix_python_targets }}"
 
   - include_tasks: install_packages.yml
 

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -24,8 +24,8 @@
     args:
       apply:
         become: False
-        environment:
-          PYTHON_TARGETS: "{{ prefix_python_targets }}"
+        #environment:
+        #  PYTHON_TARGETS: "{{ prefix_python_targets }}"
 
   - include_tasks: install_packages.yml
 


### PR DESCRIPTION
This pulls in the latest changes for the bootstrap script, uses a new snapshot, changes the snapshot URL to our S3 bucket, and bumps the versions of Python and our pilot (2021.06).