### PR TITLE
Remove step for updating the world set

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
@@ -117,11 +117,3 @@
     force: yes
   with_items:
     "{{ find_configs.results | rejectattr('files', 'equalto', []) | map(attribute='files') | list }}"
-
-- name: Update system set if we are running in an existing Prefix installation
-  portage:
-    changed_use: yes
-    deep: yes
-    package: "@world"
-    update: yes
-  when: startprefix.stat.exists


### PR DESCRIPTION
I had added this to the task as an attempt to fix the issue with the outdated awesomebytes container, but it didn't actually work. So, this can be removed again.