### PR TITLE
check target CPU architecture with build host in playbook to build compat layer

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -8,6 +8,13 @@
       The task for installing Gentoo Prefix currently only supports Linux distributions based on RHEL 8.
   when: not(ansible_os_family == "RedHat" and ansible_distribution_major_version is version("8", "=="))
 
+- name: Fail if target CPU architecture does not match with build host
+  fail:
+    msg: |
+      Error: CPU architecture of build host {{ ansible_architecture}} does not match with
+      target CPU architecture {{ eessi_host_arch }}.
+  when: not(ansible_architecture == eessi_host_arch)
+
 - name: "Install EPEL"
   yum:
     name:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -8,13 +8,6 @@
       The task for installing Gentoo Prefix currently only supports Linux distributions based on RHEL 8.
   when: not(ansible_os_family == "RedHat" and ansible_distribution_major_version is version("8", "=="))
 
-- name: Fail if target CPU architecture does not match with build host
-  fail:
-    msg: |
-      Error: CPU architecture of build host {{ ansible_architecture}} does not match with
-      target CPU architecture {{ eessi_host_arch }}.
-  when: not(ansible_architecture == eessi_host_arch)
-
 - name: "Install EPEL"
   yum:
     name:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -5,6 +5,13 @@
 # - does some fixes and other modifications in the Prefix installation (e.g. setting the locale).
 ---
 
+- name: Fail if target CPU architecture does not match with build host
+  fail:
+    msg: |
+      Error: CPU architecture of build host {{ ansible_architecture }} does not match with
+      target CPU architecture {{ eessi_host_arch }}.
+  when: not(ansible_architecture == eessi_host_arch)
+
 - name: Check if a Prefix installation is found at the specified location
   stat:
     path: "{{ gentoo_prefix_path }}/startprefix"


### PR DESCRIPTION
Only noticing that you're accidentally trying to build an `x86_64` compat layer on an `aarch64` build host *after* the Prefix bootstrap is kind of annoying...

Tested, works like a charm.