### PR TITLE
run ReFrame tests on pilot repo daily at 14:00 UTC

### DIFF
--- a/.github/workflows/pilot_repo.yml
+++ b/.github/workflows/pilot_repo.yml
@@ -1,6 +1,12 @@
 # documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
 name: Tests for EESSI pilot repo
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # run check daily at 08:00 UTC
+    # * is a special character in YAML so you have to quote this string
+    - cron: '0 14 * * *'
 jobs:
   pilot_repo:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
These tests are currently only run for PRs and when a merge is done, but I think it makes sense to also run these daily to act as canary-in-the-coal-mine, especially since they're very lightweight...