### PR TITLE
Add perl to prefix build container

### DIFF
--- a/Dockerfile.bootstrap-prefix-centos8
+++ b/Dockerfile.bootstrap-prefix-centos8
@@ -1,4 +1,4 @@
-FROM centos:8.2.2004
+FROM centos:8
 
 COPY bootstrap-prefix.sh /usr/local/bin/bootstrap-prefix.sh
 

--- a/Dockerfile.bootstrap-prefix-centos8
+++ b/Dockerfile.bootstrap-prefix-centos8
@@ -2,7 +2,7 @@ FROM centos:8
 
 COPY bootstrap-prefix.sh /usr/local/bin/bootstrap-prefix.sh
 
-RUN dnf install -y gcc gcc-c++ make diffutils gmp-devel
+RUN dnf install -y gcc gcc-c++ make diffutils gmp-devel perl
 RUN chmod 755 /usr/local/bin/bootstrap-prefix.sh
 
 ENV LC_ALL=C


### PR DESCRIPTION
(Temporary?) fix for: https://bugs.gentoo.org/824926

I've also changed the base image, which now just uses the (latest) CentOS 8 instead of pinning it to a specific 8.x version.