### PR TITLE
set GCC 9.4.0 as default compiler for 2021.12 compat layer

### DIFF
--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -42,6 +42,7 @@ Before running the playbook, make sure the following settings are correct, and o
 | prefix_required_space | Minimal amount of disk space that is required for the Gentoo Prefix bootstrap |
 | prefix_snapshot_url | Directory (served over http(s)) containing snapshot files |
 | prefix_snapshot_version | Date (`YYYYMMDD`) of the Portage snapshot file for the Prefix installation |
+| prefix_default_gcc | GCC compiler version to use as default compiler in Gentoo Prefix installation |
 | prefix_user_defined_trusted_dirs | List of paths to the user defined trusted dirs for glibc |
 | prefix_mask_packages | Contents of a [package.mask file](https://wiki.gentoo.org/wiki//etc/portage/package.mask) that should be used during the bootstrap |
 | prefix_use_builtin_bootstrap | Use the container's built-in bootstrap script? |

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -19,6 +19,7 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/{{ eessi_version }}/compat/{{ 
 prefix_required_space: 15 GB
 prefix_snapshot_url: https://eessi-gentoo-snapshot.s3-eu-west-1.amazonaws.com
 prefix_snapshot_version: 20211120
+prefix_default_gcc: 9.4.0
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"
 prefix_mask_packages: |

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -25,8 +25,6 @@
   when: cvmfs_start_transaction
 
 - block:
-  - include_tasks: prefix_configuration.yml
-
   - include_tasks: add_overlay.yml
     args:
       apply:
@@ -35,6 +33,8 @@
   - include_tasks: set_glibc_trusted_dirs.yml
 
   - include_tasks: install_packages.yml
+
+  - include_tasks: prefix_configuration.yml
 
   - include_tasks: create_host_symlinks.yml
 

--- a/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
@@ -10,6 +10,11 @@
   with_items: "{{ prefix_locales }}"
   notify: Generate locales
 
-- name: Make the most recent GCC version the default
-  command: "{{ gentoo_prefix_path }}/usr/bin/gcc-config latest"
+# Set default compiler in compat layer.
+# We should not use the latest version of GCC here, since that will probably cause problems
+# when building older GCC versions with EasyBuild in the software layer.
+# (see https://github.com/EESSI/software-layer/issues/151).
+# Note: the selected GCC version must be installed (cfr. EESSI set in gentoo-overlay)
+- name: Make specific GCC version the default compiler
+  command: "{{ gentoo_prefix_path }}/usr/bin/gcc-config 9.4.0"
   changed_when: false

--- a/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/prefix_configuration.yml
@@ -16,5 +16,5 @@
 # (see https://github.com/EESSI/software-layer/issues/151).
 # Note: the selected GCC version must be installed (cfr. EESSI set in gentoo-overlay)
 - name: Make specific GCC version the default compiler
-  command: "{{ gentoo_prefix_path }}/usr/bin/gcc-config 9.4.0"
+  command: "{{ gentoo_prefix_path }}/usr/bin/gcc-config {{ prefix_default_gcc }}"
   changed_when: false


### PR DESCRIPTION
cfr. https://github.com/EESSI/software-layer/issues/151

requires https://github.com/EESSI/gentoo-overlay/pull/72