### PR TITLE
stick to GCC 9.x for bootstrapping 2021.12 compat layer, by masking more recent GCC versions

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -26,6 +26,9 @@ prefix_mask_packages: |
   # avoid glibc 2.34, as it's causing issues with the bootstrap, and it's not compatible with CUDA 11.
   # see https://github.com/EESSI/compatibility-layer/issues/137 + https://bugs.gentoo.org/824482
   >=sys-libs/glibc-2.34
+  # stick to GCC 9.x; using a too recent compiler in the compat layer complicates stuff in the software layer,
+  # see for example https://github.com/EESSI/software-layer/issues/151
+  >=sys-devel/gcc-10
   # avoid libgcrypt 1.9.4 due to compiler errros on ppc64le,
   # see https://github.com/EESSI/compatibility-layer/issues/134 + https://bugs.gentoo.org/825722
   =dev-libs/libgcrypt-1.9.4

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -25,6 +25,8 @@
   when: cvmfs_start_transaction
 
 - block:
+  - include_tasks: prefix_configuration.yml
+
   - include_tasks: add_overlay.yml
     args:
       apply:
@@ -33,8 +35,6 @@
   - include_tasks: set_glibc_trusted_dirs.yml
 
   - include_tasks: install_packages.yml
-
-  - include_tasks: prefix_configuration.yml
 
   - include_tasks: create_host_symlinks.yml
 


### PR DESCRIPTION
cfr. https://github.com/EESSI/software-layer/issues/151

This is a better approach than in #138, since bootstrapping with a new compiler (GCC 11.2) and then "downgrading" to an older one is a recipe for disaster... :)