### PR TITLE
Use git commit instead of snapshot tarball for bootstrap, disable auto-sync, clean var/tmp

### DIFF
--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -40,8 +40,8 @@ Before running the playbook, make sure the following settings are correct, and o
 | eessi_version | Compatibility layer version, which will, by default, be included in the `gentoo_prefix_path` and be used to install the right `package_sets` |
 | gentoo_prefix_path | Path to the root of your Gentoo Prefix installation |
 | prefix_required_space | Minimal amount of disk space that is required for the Gentoo Prefix bootstrap |
-| prefix_snapshot_url | Directory (served over http(s)) containing snapshot files |
-| prefix_snapshot_version | Date (`YYYYMMDD`) of the Portage snapshot file for the Prefix installation |
+| prefix_gentoo_overlay | URL to the git repository of the Gentoo overlay |
+| prefix_gentoo_commit | Git commit hash of the Gentoo overlay repository to be used for the bootstrap |
 | prefix_default_gcc | GCC compiler version to use as default compiler in Gentoo Prefix installation |
 | prefix_user_defined_trusted_dirs | List of paths to the user defined trusted dirs for glibc |
 | prefix_mask_packages | Contents of a [package.mask file](https://wiki.gentoo.org/wiki//etc/portage/package.mask) that should be used during the bootstrap |

--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -39,9 +39,9 @@ Before running the playbook, make sure the following settings are correct, and o
 | --- | --- |
 | eessi_version | Compatibility layer version, which will, by default, be included in the `gentoo_prefix_path` and be used to install the right `package_sets` |
 | gentoo_prefix_path | Path to the root of your Gentoo Prefix installation |
+| gentoo_git_repo | URL to the git repository of the (official) Gentoo ebuild repository |
+| gentoo_git_commit | Git commit hash of the Gentoo ebuild repository to be used for the bootstrap |
 | prefix_required_space | Minimal amount of disk space that is required for the Gentoo Prefix bootstrap |
-| prefix_gentoo_overlay | URL to the git repository of the Gentoo overlay |
-| prefix_gentoo_commit | Git commit hash of the Gentoo overlay repository to be used for the bootstrap |
 | prefix_default_gcc | GCC compiler version to use as default compiler in Gentoo Prefix installation |
 | prefix_user_defined_trusted_dirs | List of paths to the user defined trusted dirs for glibc |
 | prefix_mask_packages | Contents of a [package.mask file](https://wiki.gentoo.org/wiki//etc/portage/package.mask) that should be used during the bootstrap |

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -19,6 +19,8 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/c
 prefix_required_space: 15 GB
 prefix_snapshot_url: https://eessi-gentoo-snapshot.s3-eu-west-1.amazonaws.com
 prefix_snapshot_version: 20211120
+prefix_gentoo_overlay: https://github.com/gentoo/gentoo
+prefix_gentoo_commit: 7eaa2512d1e6ddb44e3b41bbddf6c74723f234ce
 prefix_default_gcc: 9.4.0
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -15,10 +15,12 @@ cvmfs_repository: pilot.eessi-hpc.org
 
 gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}
 
-# How to build the prefix
+# How to build the prefix.
+gentoo_git_repo: https://github.com/gentoo/gentoo.git
+# Select a specific commit in the gentoo_git_repo that should be used for the bootstrap,
+# e.g. by checking: https://github.com/gentoo/gentoo/commits/master
+gentoo_git_commit: 7eaa2512d1e6ddb44e3b41bbddf6c74723f234ce
 prefix_required_space: 15 GB
-prefix_gentoo_overlay: https://github.com/gentoo/gentoo
-prefix_gentoo_commit: 7eaa2512d1e6ddb44e3b41bbddf6c74723f234ce
 prefix_default_gcc: 9.4.0
 prefix_user_defined_trusted_dirs:
   - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib"

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -17,8 +17,6 @@ gentoo_prefix_path: /cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/c
 
 # How to build the prefix
 prefix_required_space: 15 GB
-prefix_snapshot_url: https://eessi-gentoo-snapshot.s3-eu-west-1.amazonaws.com
-prefix_snapshot_version: 20211120
 prefix_gentoo_overlay: https://github.com/gentoo/gentoo
 prefix_gentoo_commit: 7eaa2512d1e6ddb44e3b41bbddf6c74723f234ce
 prefix_default_gcc: 9.4.0
@@ -43,8 +41,6 @@ prefix_source: "docker://ghcr.io/eessi/bootstrap-prefix:centos8"
 prefix_source_options: "{{ gentoo_prefix_path }} noninteractive"
 prefix_install: >-
     SINGULARITYENV_USE_CPU_CORES={{ ansible_processor_vcpus }}
-    SINGULARITYENV_CUSTOM_SNAPSHOT_URL="{{ prefix_snapshot_url }}"
-    SINGULARITYENV_CUSTOM_SNAPSHOT_VERSION="{{ prefix_snapshot_version }}"
     {{ prefix_singularity_command }} {{ prefix_source }}
     {{ prefix_use_builtin_bootstrap | ternary('/usr/local/bin/bootstrap-prefix.sh', prefix_custom_bootstrap_script.remote) }}
     {{ prefix_source_options }}

--- a/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
@@ -52,48 +52,6 @@
         selectattr('eclass-overrides', 'equalto', True) | map(attribute='name') | join(' ')
       }}
 
-- name: Use git instead of rsync for the Gentoo overlay
-  copy:
-    dest: "{{ gentoo_prefix_path }}/etc/portage/repos.conf/gentoo.conf"
-    mode: "0644"
-    content: |
-      [DEFAULT]
-      main-repo = gentoo
-      sync-git-pull-extra-opts = --quiet
-
-      [gentoo]
-      priority  = 1
-      location  = {{ gentoo_prefix_path }}/var/db/repos/gentoo
-      sync-uri  = https://github.com/gentoo/gentoo.git
-      sync-type = git
-      auto-sync = Yes
-      clone-depth = 1
-  register: copy_gentoo_git_config
-
-- name: Create repo.postsync.d directory
-  file:
-    path: "{{ gentoo_prefix_path }}/etc/portage/repo.postsync.d"
-    state: directory
-    mode: '0755'
-
-- name: Add post-sync hooks for Gentoo overlay
-  copy:
-    src: "{{ item }}"
-    dest: "{{ gentoo_prefix_path }}/etc/portage/repo.postsync.d/{{ item }}"
-    mode: 0755
-  with_items:
-    - sync_gentoo_cache
-    - sync_gentoo_dtd
-    - sync_gentoo_glsa
-    - sync_gentoo_news
-    - sync_overlay_cache
-
-- name: Remove the old Gentoo overlay directory
-  file:
-    state: absent
-    path: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
-  when: copy_gentoo_git_config is changed
-
 - name: Sync the repositories
   portage:
     sync: 'yes'

--- a/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
@@ -19,12 +19,6 @@
     cmd: emerge gentoolkit
     creates: "{{ gentoo_prefix_path }}/usr/bin/equery"
 
-- name: Create repos directory
-  file:
-    path: "{{ gentoo_prefix_path }}/etc/portage/repos.conf"
-    state: directory
-    mode: '0755'
-
 - name: Install eselect-repository
   portage:
     package: eselect-repository

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -135,7 +135,7 @@
     repo: "{{ prefix_gentoo_overlay }}"
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     depth: 1
-    version: "HEAD"
+    version: master
   tags:
     - build_prefix
 
@@ -146,6 +146,7 @@
     clone: no
     refspec: "{{ prefix_gentoo_commit }}"
     depth: 1
+    version: master
   tags:
     - build_prefix
 

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -135,6 +135,7 @@
     repo: "{{ prefix_gentoo_overlay }}"
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     depth: 1
+    version: "HEAD"
   tags:
     - build_prefix
 

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -17,10 +17,11 @@
   tags:
     - build_prefix
 
-- name: "Install other requirements (Singularity et al.)"
+- name: "Install other requirements (Singularity and git)"
   yum:
     name:
       - singularity
+      - git
     state: present
   tags:
     - build_prefix

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -80,6 +80,48 @@
   tags:
     - build_prefix
 
+- name: Configure Gentoo overlay
+  copy:
+    dest: "{{ gentoo_prefix_path }}/etc/portage/repos.conf/gentoo.conf"
+    mode: "0644"
+    content: |
+      [DEFAULT]
+      main-repo = gentoo
+      sync-git-pull-extra-opts = --quiet
+
+      [gentoo]
+      priority  = 1
+      location  = {{ gentoo_prefix_path }}/var/db/repos/gentoo
+      sync-uri  = https://github.com/gentoo/gentoo.git
+      sync-type = git
+      auto-sync = no
+      clone-depth = 1
+  register: copy_gentoo_git_config
+  tags:
+    - build_prefix
+
+- name: Create repo.postsync.d directory
+  file:
+    path: "{{ gentoo_prefix_path }}/etc/portage/repo.postsync.d"
+    state: directory
+    mode: '0755'
+  tags:
+    - build_prefix
+
+- name: Add post-sync hooks for Gentoo overlay
+  copy:
+    src: "{{ item }}"
+    dest: "{{ gentoo_prefix_path }}/etc/portage/repo.postsync.d/{{ item }}"
+    mode: 0755
+  with_items:
+    - sync_gentoo_cache
+    - sync_gentoo_dtd
+    - sync_gentoo_glsa
+    - sync_gentoo_news
+    - sync_overlay_cache
+  tags:
+    - build_prefix
+
 - name: "Mask packages for the bootstrap"
   copy:
     dest: "{{ gentoo_prefix_path }}/etc/portage/package.mask"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -122,6 +122,35 @@
   tags:
     - build_prefix
 
+- name: "Make directory for the Gentoo overlay"
+  file:
+    path: "{{ gentoo_prefix_path }}/var/db/repos"
+    mode: '0755'
+    state: directory
+  tags:
+    - build_prefix
+
+- name: "Clone the Gentoo git repository into the overlay directory"
+  git:
+    repo: "{{ prefix_gentoo_overlay }}"
+    dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
+    depth: 1
+
+- name: "Fetch the specific git commit to be used for the bootstrap"
+  git:
+    repo: "{{ prefix_gentoo_overlay }}"
+    dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
+    clone: no
+    refspec: "{{ prefix_gentoo_commit }}"
+    depth: 1
+
+- name: "Checkout the fetched git commit"
+  git:
+    repo: "{{ prefix_gentoo_overlay }}"
+    dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
+    clone: no
+    version: "{{ prefix_gentoo_commit }}"
+
 - name: "Mask packages for the bootstrap"
   copy:
     dest: "{{ gentoo_prefix_path }}/etc/portage/package.mask"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -190,6 +190,19 @@
   tags:
     - build_prefix
 
+- name: "Find files and directories in $EPREFIX/var/tmp"
+  find:
+    path: "{{ gentoo_prefix_path }}/var/tmp"
+    file_type: any
+    recurse: no
+  register: var_tmp_contents
+
+- name: "Clean up all files and directories found in $EPREFIX/var/tmp"
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ var_tmp_contents.files }}"
+
 - name: "Check if startprefix script has been created"
   stat:
     path: "{{ gentoo_prefix_path }}/startprefix"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -157,6 +157,9 @@
   tags:
     - build_prefix
 
+# If a file named .unpacked is present in the root of the gentoo overlay directory,
+# the bootstrap script will not extract a Portage tree snapshot file to that same directory.
+# See the do_tree() function in the bootstrap-prefix.sh script.
 - name: "Prevent our git checkout from being overwritten by making an '.unpacked' file"
   copy:
     content: ""

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -158,9 +158,9 @@
     - build_prefix
 
 - name: "Prevent our git checkout from being overwritten by making an '.unpacked' file"
-  file:
-    path: "{{ gentoo_prefix_path }}/var/db/repos/gentoo/.unpacked"
-    state: file
+  copy:
+    content: ""
+    dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo/.unpacked"
     mode: '0644'
   tags:
     - build_prefix

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -71,9 +71,9 @@
   tags:
     - build_prefix
 
-- name: "Create $EPREFIX/etc/portage directory"
+- name: "Create $EPREFIX/etc/portage/repos.conf directory"
   file:
-    path: "{{ gentoo_prefix_path }}/etc/portage"
+    path: "{{ gentoo_prefix_path }}/etc/portage/repos.conf"
     state: directory
     mode: 0755
   when: prefix_mask_packages is defined and prefix_mask_packages | length > 0

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -135,6 +135,8 @@
     repo: "{{ prefix_gentoo_overlay }}"
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     depth: 1
+  tags:
+    - build_prefix
 
 - name: "Fetch the specific git commit to be used for the bootstrap"
   git:
@@ -143,6 +145,8 @@
     clone: no
     refspec: "{{ prefix_gentoo_commit }}"
     depth: 1
+  tags:
+    - build_prefix
 
 - name: "Checkout the fetched git commit"
   git:
@@ -150,6 +154,16 @@
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     clone: no
     version: "{{ prefix_gentoo_commit }}"
+  tags:
+    - build_prefix
+
+- name: "Prevent our git checkout from being overwritten by making an '.unpacked' file"
+  file:
+    path: "{{ gentoo_prefix_path }}/var/db/repos/gentoo/.unpacked"
+    state: file
+    mode: '0644'
+  tags:
+    - build_prefix
 
 - name: "Mask packages for the bootstrap"
   copy:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -92,7 +92,7 @@
       [gentoo]
       priority  = 1
       location  = {{ gentoo_prefix_path }}/var/db/repos/gentoo
-      sync-uri  = https://github.com/gentoo/gentoo.git
+      sync-uri  = {{ gentoo_git_repo }}
       sync-type = git
       auto-sync = no
       clone-depth = 1
@@ -132,7 +132,7 @@
 
 - name: "Clone the Gentoo git repository into the overlay directory"
   git:
-    repo: "{{ prefix_gentoo_overlay }}"
+    repo: "{{ gentoo_git_repo }}"
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     depth: 1
     version: master
@@ -141,10 +141,10 @@
 
 - name: "Fetch the specific git commit to be used for the bootstrap"
   git:
-    repo: "{{ prefix_gentoo_overlay }}"
+    repo: "{{ gentoo_git_repo }}"
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     clone: no
-    refspec: "{{ prefix_gentoo_commit }}"
+    refspec: "{{ gentoo_git_commit }}"
     depth: 1
     version: master
   tags:
@@ -152,10 +152,10 @@
 
 - name: "Checkout the fetched git commit"
   git:
-    repo: "{{ prefix_gentoo_overlay }}"
+    repo: "{{ gentoo_git_repo }}"
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     clone: no
-    version: "{{ prefix_gentoo_commit }}"
+    version: "{{ gentoo_git_commit }}"
   tags:
     - build_prefix
 

--- a/bootstrap-prefix.sh
+++ b/bootstrap-prefix.sh
@@ -578,10 +578,10 @@ bootstrap_tree() {
 	# RAP uses the latest gentoo main repo snapshot to bootstrap.
 	is-rap && LATEST_TREE_YES=1
 	local PV="20211105"
-	if is-rap ; then
-		do_tree "${CUSTOM_SNAPSHOT_URL:-$SNAPSHOT_URL}" portage-${CUSTOM_SNAPSHOT_VERSION:-latest}.tar.bz2
+	if [[ -n ${LATEST_TREE_YES} ]]; then
+		do_tree "${SNAPSHOT_URL}" portage-latest.tar.bz2
 	else
-		do_tree "${CUSTOM_SNAPSHOT_URL:-http://dev.gentoo.org/~grobian/distfiles}" prefix-overlay-${CUSTOM_SNAPSHOT_VERSION:-$PV}.tar.bz2
+		do_tree http://dev.gentoo.org/~grobian/distfiles prefix-overlay-${PV}.tar.bz2
 	fi
 	local ret=$?
 	if [[ -n ${TREE_FROM_SRC} ]]; then


### PR DESCRIPTION
These changes will make the bootstrap script use a prefetched git commit from the Gentoo overlay on GitHub, removing the need to provide a snapshot tarball. This gives us more fine-grained control over what should be used as base for the bootstrap.

Furthermore, it sets `auto-sync = no`, which will basically ignore the `emerge --sync` that the bootstrap usually does. This should make the build much more reproducible. @boegel is this enough to close issue #132?

Finally, it also adds a simple step that removes the contents of `$EPREFIX/var/tmp` after completion of the bootstrap process, i.e. it closes #142.