### PR TITLE
May the force be with the git clone step

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/install_prefix.yml
@@ -135,6 +135,7 @@
     repo: "{{ gentoo_git_repo }}"
     dest: "{{ gentoo_prefix_path }}/var/db/repos/gentoo"
     depth: 1
+    force: yes
     version: master
   tags:
     - build_prefix


### PR DESCRIPTION
This will discard any changes in the gentoo git repo directory when rerunning the playbook, and should prevent issues like:
```
TASK [compatibility_layer : Clone the Gentoo git repository into the overlay directory] *************
fatal: [localhost]: FAILED! => {"before": "7eaa2512d1e6ddb44e3b41bbddf6c74723f234ce", "changed": false, "msg": "Local modifications exist in repository (force=no)."}
```