### PR TITLE
Add a cleanup task to the Ansible role

### DIFF
--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -55,6 +55,7 @@ Before running the playbook, make sure the following settings are correct, and o
 | prefix_locales | List of locales to be generated |
 | package_sets | List of package sets to be installed |
 | prefix_packages | List of additional packages to be installed |
+| prefix_remove_packages | List of packages to be removed after the bootstrap |
 | symlinks_to_host | List of paths that should get a symlink to the corresponding host path |
 
 ### Logging

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -64,6 +64,10 @@ package_sets:
 
 prefix_packages:
 
+prefix_remove_packages:
+  - dev-lang/go
+  - dev-lang/go-bootstrap
+
 # List of locations that should get a symlink $EPREFIX/$LOCATION -> $LOCATION.
 # This ensures that things like user/group ids are correct/looked up in the right way in the Prefix environment.
 symlinks_to_host:

--- a/ansible/playbooks/roles/compatibility_layer/tasks/cleanup.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/cleanup.yml
@@ -1,0 +1,7 @@
+# Clean up
+---
+- name: Remove redundant packages
+  community.general.portage:
+    package: "{{ item }}"
+    state: absent
+  with_items: "{{ prefix_remove_packages }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -45,6 +45,9 @@
     - name: Create symlinks to host files
       ansible.builtin.include_tasks: create_host_symlinks.yml
 
+    - name: Clean up
+      ansible.builtin.include_tasks: cleanup.yml
+
     - name: Test the Prefix installation
       ansible.builtin.include_tasks: test.yml
       tags:


### PR DESCRIPTION
This can be used to remove stuff at the end of the installation, currently it will just remove a list of specified packages (`Go`, only used for building `direnv`).