### PR TITLE
add python-is-python3 and portage to bootstrap container

### DIFF
--- a/Dockerfile.bootstrap-prefix-debian11
+++ b/Dockerfile.bootstrap-prefix-debian11
@@ -4,9 +4,9 @@ COPY bootstrap-prefix.sh /usr/local/bin/bootstrap-prefix.sh
 
 RUN apt-get update
 RUN apt-get install -y gcc g++ make diffutils libgmp-dev perl wget
-RUN apt-get install -y git python3-pip python3-cryptography
+RUN apt-get install -y git python3-pip python3-cryptography python-is-python3
 RUN pip3 install --upgrade pip
-RUN pip3 install ansible
+RUN pip3 install ansible portage
 RUN chmod 755 /usr/local/bin/bootstrap-prefix.sh
 
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
The task to install `eselect-repository` failed without `python-is-python3` and `portage`.

For the former, see https://unix.stackexchange.com/questions/609855/how-to-make-python-an-alias-of-python3-systemwide-on-debian/617643#617643

For the latter, just the portage python module was missing.

With this PR both packages are added to the container. The building of the compatibility layer finishes.

Not entirely sure if these packages shall be provided by the container or the bootstrapped prefix.
