### PR TITLE
Add and update scripts

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -1,10 +1,88 @@
 #!/bin/bash
+#
+# script to build the EESSI compatibility layer. Intended use is that it is called
+# by a (batch) job running on a compute node.
+#
+# This script is part of the EESSI compatibility layer, see
+# https://github.com/EESSI/compatibility-layer.git
+#
+# author: Bob Droege (@bedroge)
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
 
-cpu_target_arch=$(echo ${CPU_TARGET} | cut -d/ -f1)
+# ASSUMPTIONs:
+#  - working directory has been prepared by the bot with a checkout of a
+#    pull request (OR by some other means)
+#  - the working directory contains a directory 'cfg' where the main config
+#    file 'job.cfg' has been deposited
+#  - the directory may contain any additional files referenced in job.cfg
+
+# stop as soon as something fails
+set -e
+
+# source utils.sh and cfg_files.sh
+source scripts/utils.sh
+source scripts/cfg_files.sh
+
+# defaults
+export JOB_CFG_FILE="${JOB_CFG_FILE_OVERRIDE:=./cfg/job.cfg}"
+
+# check if ${JOB_CFG_FILE} exists
+if [[ ! -r "${JOB_CFG_FILE}" ]]; then
+    fatal_error "job config file (JOB_CFG_FILE=${JOB_CFG_FILE}) does not exist or not readable"
+fi
+echo "bot/build.sh: showing ${JOB_CFG_FILE} from software-layer side"
+cat ${JOB_CFG_FILE}
+
+echo "bot/build.sh: obtaining configuration settings from '${JOB_CFG_FILE}'"
+cfg_load ${JOB_CFG_FILE}
+
+# if http_proxy is defined in ${JOB_CFG_FILE} use it, if not use env var $http_proxy
+HTTP_PROXY=$(cfg_get_value "site_config" "http_proxy")
+HTTP_PROXY=${HTTP_PROXY:-${http_proxy}}
+echo "bot/build.sh: HTTP_PROXY='${HTTP_PROXY}'"
+
+# if https_proxy is defined in ${JOB_CFG_FILE} use it, if not use env var $https_proxy
+HTTPS_PROXY=$(cfg_get_value "site_config" "https_proxy")
+HTTPS_PROXY=${HTTPS_PROXY:-${https_proxy}}
+echo "bot/build.sh: HTTPS_PROXY='${HTTPS_PROXY}'"
+
+LOCAL_TMP=$(cfg_get_value "site_config" "local_tmp")
+echo "bot/build.sh: LOCAL_TMP='${LOCAL_TMP}'"
+
+echo -n "setting \$STORAGE by replacing any var in '${LOCAL_TMP}' -> "
+# replace any env variable in ${LOCAL_TMP} with its
+#   current value (e.g., a value that is local to the job)
+STORAGE=$(envsubst <<< ${LOCAL_TMP})
+echo "'${STORAGE}'"
+
+# make sure ${STORAGE} exists
+mkdir -p ${STORAGE}
+
+# obtain list of modules to be loaded
+LOAD_MODULES=$(cfg_get_value "site_config" "load_modules")
+echo "bot/build.sh: LOAD_MODULES='${LOAD_MODULES}'"
+
+# load modules if LOAD_MODULES is not empty
+if [[ ! -z ${LOAD_MODULES} ]]; then
+    for mod in $(echo ${LOAD_MODULES} | tr ',' '\n')
+    do
+        echo "bot/build.sh: loading module '${mod}'"
+        module load ${mod}
+    done
+else
+    echo "bot/build.sh: no modules to be loaded"
+fi
+
+#####################################################
+# cpu_target_arch=$(echo ${CPU_TARGET} | cut -d/ -f1)
+cpu_target_arch=$(cfg_get_value "architecture" "software_subdir" | cut -d/ -f1)
 host_arch=$(uname -m)
 eessi_arch=${cpu_target_arch:-${host_arch}}
 eessi_os=linux
-eessi_version=2023.02
+eessi_version=2023.04
 eessi_repo=pilot.eessi-hpc.org
 tar_topdir=/cvmfs/${eessi_repo}/versions
 
@@ -13,7 +91,8 @@ if [ "${eessi_arch}" != "${host_arch}" ]; then
   exit 1
 fi
 
-./install_compatibility_layer.sh -a ${eessi_arch} -v ${eessi_version} -r ${eessi_repo} -c ~/compat.sif
+#./install_compatibility_layer.sh -a ${eessi_arch} -v ${eessi_version} -r ${eessi_repo} -c ~/compat.sif
+./install_compatibility_layer.sh -a ${eessi_arch} -v ${eessi_version} -r ${eessi_repo} -g ${STORAGE}
 
 # create tarball -> should go into a separate script when this is supported by the bot
 target_tgz=eessi-${eessi_version}-compat-linux-${eessi_arch}-$(date +%s).tar.gz

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -76,14 +76,14 @@ else
     echo "bot/build.sh: no modules to be loaded"
 fi
 
-#####################################################
-# cpu_target_arch=$(echo ${CPU_TARGET} | cut -d/ -f1)
 cpu_target_arch=$(cfg_get_value "architecture" "software_subdir" | cut -d/ -f1)
 host_arch=$(uname -m)
 eessi_arch=${cpu_target_arch:-${host_arch}}
 eessi_os=linux
-eessi_version=2023.04
-eessi_repo=pilot.eessi-hpc.org
+job_version=$(cfg_get_value "repository" "repo_version")
+eessi_version=${job_version:-2023.04}
+job_repo=$(cfg_get_value "repository" "repo_name")
+eessi_repo=${job_repo:-pilot.eessi-hpc.org}
 tar_topdir=/cvmfs/${eessi_repo}/versions
 
 if [ "${eessi_arch}" != "${host_arch}" ]; then
@@ -91,7 +91,6 @@ if [ "${eessi_arch}" != "${host_arch}" ]; then
   exit 1
 fi
 
-#./install_compatibility_layer.sh -a ${eessi_arch} -v ${eessi_version} -r ${eessi_repo} -c ~/compat.sif
 ./install_compatibility_layer.sh -a ${eessi_arch} -v ${eessi_version} -r ${eessi_repo} -g ${STORAGE}
 
 # create tarball -> should go into a separate script when this is supported by the bot

--- a/install_compatibility_layer.sh
+++ b/install_compatibility_layer.sh
@@ -10,7 +10,7 @@ REPOSITORY="pilot.eessi-hpc.org"
 RESUME=
 RETAIN_TMP=0
 STORAGE=
-VERSION=
+VERSION=2023.04
 VERBOSE=
 
 display_help() {
@@ -141,6 +141,7 @@ echo "Using $EESSI_TMPDIR as temporary storage..."
 # Create temporary directories
 mkdir -p ${EESSI_TMPDIR}/cvmfs
 mkdir -p ${EESSI_TMPDIR}/home
+mkdir -p ${EESSI_TMPDIR}/tmp
 
 RUNTIME=$(get_container_runtime)
 exit_code=$?
@@ -158,6 +159,7 @@ if [[ -z ${SINGULARITY_CACHEDIR} ]]; then
   export SINGULARITY_CACHEDIR=${EESSI_TMPDIR}/apptainer_cache
 fi
 export SINGULARITY_BIND="${EESSI_TMPDIR}/cvmfs:/cvmfs,${SCRIPT_DIR}:/compatibility-layer"
+export SINGULARITY_BIND="${SINGULARITY_BIND},${EESSI_TMPDIR}/tmp:/tmp"
 export SINGULARITY_HOME="${EESSI_TMPDIR}/home:/home/${USER}"
 
 # Construct the Ansible playbook command
@@ -183,7 +185,8 @@ EOF
 
 if [[ ${RETAIN_TMP} -eq 1 ]]; then
   echo "Left container; tar'ing up ${EESSI_TMPDIR} for future inspection"
-  tar cvzf ${SCRIPT_DIR}/job_${SLURM_JOB_ID}_$(date +%s).tgz -C ${EESSI_TMPDIR} .
+  ID=${SLURM_JOB_ID:-$$}
+  tar cvzf ${SCRIPT_DIR}/job_${ID}_$(date +%s).tgz -C ${EESSI_TMPDIR} .
 fi
 
 echo "To resume work add '--resume ${EESSI_TMPDIR}'"

--- a/install_compatibility_layer.sh
+++ b/install_compatibility_layer.sh
@@ -7,22 +7,46 @@
 ARCH=
 CONTAINER=docker://ghcr.io/eessi/bootstrap-prefix:debian11
 REPOSITORY="pilot.eessi-hpc.org"
+RESUME=
+RETAIN_TMP=0
 STORAGE=
 VERSION=
+VERBOSE=
 
 display_help() {
   echo "usage: $0 [OPTIONS]"
-  echo " OPTIONS:"
-  echo "  -a | --arch ARCH       - architecture to build a compatibility layer for"
-  echo "                           [default/required: current host's architecture]"
-  echo "  -c | --container IMG   - image file or URL defining the container to use"
-  echo "                           [default: ${CONTAINER}"
-  echo "  -g | --storage DIR     - directory space on host machine (used for"
-  echo "                           temporary data) [default: 1. TMPDIR, 2. /tmp]"
-  echo "  -h | --help            - display this usage information"
-  echo "  -r | --repository REPO - CVMFS repository name [default: ${REPOSITORY}]"
-  echo "  -v | --version VERSION - override the EESSI stack version set in Ansible's"
-  echo "                           defaults/main.yml file [default: None]"
+  echo "OPTIONS:"
+  echo "    -a | --arch ARCHITECTURE"
+  echo "        architecture to build a compatibility layer for"
+  echo "        [default/required: current host's architecture]"
+  echo ""
+  echo "    -c | --container IMAGE"
+  echo "        image file or URL defining the container to use"
+  echo "        [default: ${CONTAINER}]"
+  echo ""
+  echo "    -g | --storage DIRECTORY"
+  echo "        directory space on host machine (used for"
+  echo "        temporary data) [default: 1. TMPDIR, 2. /tmp]"
+  echo ""
+  echo "    -k | --retain-tmp"
+  echo "        retain tmp storage (as tarball) for future"
+  echo "        inspection [default: not set]"
+  echo ""
+  echo "    -h | --help"
+  echo "        display this usage information"
+  echo ""
+  echo "    -r | --repository REPO"
+  echo "        CVMFS repository name [default: ${REPOSITORY}]"
+  echo ""
+  echo "    -t | --resume TMPDIR"
+  echo "        tmp directory to resume from [default: None]"
+  echo ""
+  echo "    -v | --version VERSION"
+  echo "        override the EESSI stack version set in Ansible's"
+  echo "        defaults/main.yml file [default: None]"
+  echo ""
+  echo "    --verbose"
+  echo "        increase verbosity of output [default: not set]"
   echo
 }
 
@@ -42,6 +66,10 @@ while [[ $# -gt 0 ]]; do
       STORAGE="$2"
       shift 2
       ;;
+    -k|--retain-tmp)
+      RETAIN_TMP=1
+      shift 1
+      ;;
     -h|--help)
       display_help
       exit 0
@@ -50,9 +78,17 @@ while [[ $# -gt 0 ]]; do
       REPOSITORY="$2"
       shift 2
       ;;
+    -t|--resume)
+      RESUME="$2"
+      shift 2
+      ;;
     -v|--version)
       VERSION="$2"
       shift 2
+      ;;
+    --verbose)
+      VERBOSE="-vvv"
+      shift 1
       ;;
     -*|--*)
       fatal_error "Unknown option: $1" "${CMDLINE_ARG_UNKNOWN_EXITCODE}"
@@ -75,6 +111,9 @@ if [ ! -f "${SCRIPT_DIR}/ansible/playbooks/install.yml" ]; then
     exit 1
 fi
 
+# source utils.sh (for get_container_runtime and check_exit_code)
+source ${SCRIPT_DIR}/scripts/utils.sh
+
 # Check if the target architecture is set to the architecture of the current host,
 # as that's the only thing that's currently supported by this script
 HOST_ARCH=$(uname -m)
@@ -88,19 +127,38 @@ fi
 echo "A compatibility layer for architecture ${ARCH} will be built."
 
 # Make a temporary directory on the host for storing the installation and some temporary files
-TMPDIR=${STORAGE:-${TMPDIR:-/tmp}}
-mkdir -p ${TMPDIR}
-EESSI_TMPDIR=$(mktemp -d --tmpdir eessi.XXXXXXXXXX)
+if [[ ! -z ${RESUME} ]] && [[ -d ${RESUME} ]]; then
+    EESSI_TMPDIR=${RESUME}
+    echo "using previous temporary storage at ${RESUME} to resume work"
+else
+    TMPDIR=${STORAGE:-${TMPDIR:-/tmp}}
+    mkdir -p ${TMPDIR}
+    EESSI_TMPDIR=$(mktemp -d --tmpdir=${TMPDIR} eessi.XXXXXXXXXX)
+    echo "created new temporary storage at ${EESSI_TMPDIR}"
+fi
 echo "Using $EESSI_TMPDIR as temporary storage..."
 
 # Create temporary directories
 mkdir -p ${EESSI_TMPDIR}/cvmfs
 mkdir -p ${EESSI_TMPDIR}/home
 
+RUNTIME=$(get_container_runtime)
+exit_code=$?
+echo "RUNTIME='${RUNTIME}'"
+check_exit_code ${exit_code} "using runtime ${RUNTIME}" "oh no, neither apptainer nor singularity available"
+
 # Set up paths and mount points for Apptainer
-export APPTAINER_CACHEDIR=${EESSI_TMPDIR}/apptainer_cache
+if [[ -z ${APPTAINER_CACHEDIR} ]]; then
+  export APPTAINER_CACHEDIR=${EESSI_TMPDIR}/apptainer_cache
+fi
 export APPTAINER_BIND="${EESSI_TMPDIR}/cvmfs:/cvmfs,${SCRIPT_DIR}:/compatibility-layer"
 export APPTAINER_HOME="${EESSI_TMPDIR}/home:/home/${USER}"
+# also define SINGULARITY_* env vars
+if [[ -z ${SINGULARITY_CACHEDIR} ]]; then
+  export SINGULARITY_CACHEDIR=${EESSI_TMPDIR}/apptainer_cache
+fi
+export SINGULARITY_BIND="${EESSI_TMPDIR}/cvmfs:/cvmfs,${SCRIPT_DIR}:/compatibility-layer"
+export SINGULARITY_HOME="${EESSI_TMPDIR}/home:/home/${USER}"
 
 # Construct the Ansible playbook command
 ANSIBLE_OPTIONS="-e eessi_host_os=linux -e eessi_host_arch=$(uname -m)"
@@ -110,11 +168,22 @@ fi
 if [[ ! -z ${REPOSITORY} ]]; then
     ANSIBLE_OPTIONS="${ANSIBLE_OPTIONS} -e cvmfs_repository=${REPOSITORY}"
 fi
+if [[ ! -z ${VERBOSE} ]]; then
+    ANSIBLE_OPTIONS="${ANSIBLE_OPTIONS} ${VERBOSE}"
+fi
 ANSIBLE_COMMAND="ansible-playbook ${ANSIBLE_OPTIONS} /compatibility-layer/ansible/playbooks/install.yml"
 # Finally, run Ansible inside the container to do the actual installation
 echo "Executing ${ANSIBLE_COMMAND} in ${CONTAINER}, this will take a while..."
-apptainer shell ${CONTAINER} <<EOF
+${RUNTIME} shell ${CONTAINER} <<EOF
 # The Gentoo Prefix bootstrap script will complain if $LD_LIBRARY_PATH is set
 unset LD_LIBRARY_PATH
+unset PKG_CONFIG_PATH
 ${ANSIBLE_COMMAND}
 EOF
+
+if [[ ${RETAIN_TMP} -eq 1 ]]; then
+  echo "Left container; tar'ing up ${EESSI_TMPDIR} for future inspection"
+  tar cvzf ${SCRIPT_DIR}/job_${SLURM_JOB_ID}_$(date +%s).tgz -C ${EESSI_TMPDIR} .
+fi
+
+echo "To resume work add '--resume ${EESSI_TMPDIR}'"

--- a/scripts/cfg_files.sh
+++ b/scripts/cfg_files.sh
@@ -1,0 +1,167 @@
+# functions for working with ini/cfg files
+#
+# This file is part of the EESSI software layer, see
+# https://github.com/EESSI/software-layer.git
+#
+# author: Thomas Roeblitz (@trz42)
+#
+# license: GPLv2
+#
+
+
+# global variables
+# -a -> indexed array
+# -A -> associative array
+declare -A cfg_repos
+declare -A cfg_file_map
+
+
+# functions
+function cfg_get_section {
+  if [[ "$1" =~ ^(\[)(.*)(\])$ ]]; then
+    echo ${BASH_REMATCH[2]}
+  else
+    echo ""
+  fi
+}
+
+function cfg_get_key_value {
+  if [[ "$1" =~ ^([^=]+)=([^=]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
+  else
+    echo ""
+  fi
+}
+
+function cfg_load {
+  local cur_section=""
+  local cur_key=""
+  local cur_val=""
+  IFS=
+  while read -r line; do
+    new_section=$(cfg_get_section $line)
+    # got a new section
+    if [[ -n "$new_section" ]]; then
+      cur_section=$new_section
+    # not a section, try a key value
+    else
+      val=$(cfg_get_key_value $line)
+      # trim leading and trailing spaces as well
+      cur_key=$(echo $val | cut -f1 -d'=' | cfg_trim_spaces)
+      cur_val=$(echo $val | cut -f2 -d'=' | cfg_trim_spaces)
+      if [[ -n "$cur_key" ]]; then
+        # section + key is the associative in bash array, the field separator is space
+        cfg_repos[${cur_section} ${cur_key}]=$cur_val
+      fi
+    fi
+  done <$1
+}
+
+function cfg_print {
+  for index in "${!cfg_repos[@]}"
+  do
+    # split the associative key in to section and key
+    echo -n "section  : $(echo $index | cut -f1 -d ' ');"
+    echo -n "key  : $(echo $index | cut -f2 -d ' ');"
+    echo  "value: ${cfg_repos[$index]}"
+  done
+}
+
+function cfg_sections {
+  declare -A sections
+  for key in "${!cfg_repos[@]}"
+  do
+    # extract section from the associative key
+    section=$(echo $key | cut -f1 -d ' ')
+    sections[${section}]=1
+  done
+  for repo in "${!sections[@]}"
+  do
+      echo "${repo}"
+  done
+}
+
+function cfg_get_value {
+  section=$1
+  key=$2
+  echo "${cfg_repos[$section $key]}"
+}
+
+function cfg_trim_spaces {
+  # reads from argument $1 or stdin
+  if [[ $# -gt 0 ]]; then
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' <<< ${1}
+  else
+    sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' < /dev/stdin
+  fi
+}
+
+function cfg_trim_quotes {
+  # reads from argument $1 or stdin
+  if [[ $# -gt 0 ]]; then
+    sed -e 's/^"*//' -e 's/"*$//' <<< ${1}
+  else
+    sed -e 's/^"*//' -e 's/"*$//' < /dev/stdin
+  fi
+}
+
+function cfg_trim_curly_brackets {
+  # reads from argument $1 or stdin
+  if [[ $# -gt 0 ]]; then
+    sed -e 's/^{*//' -e 's/}*$//' <<< ${1}
+  else
+    sed -e 's/^{*//' -e 's/}*$//' < /dev/stdin
+  fi
+}
+
+function cfg_get_all_sections {
+  # first field in keys
+  # 1. get first field in all keys, 2. filter duplicates, 3. return them as string
+  declare -A all_sections
+  for key in "${!cfg_repos[@]}"
+  do
+    section=$(echo "$key" | cut -f1 -d' ')
+    all_sections[${section}]=1
+  done
+  sections=
+  for sec_key in "${!all_sections[@]}"
+  do
+    sections="${sections} ${sec_key}"
+  done
+  echo "${sections}" | cfg_trim_spaces
+}
+
+function cfg_init_file_map {
+  # strip '{' and '}' from config_map
+  # split config_map at ','
+  # for each item: split at ':' use first as key, second as value
+
+  # reset global variable
+  cfg_file_map=()
+
+  # expects a string containing the config_map from the cfg file
+  # trim leading and trailing curly brackets
+  cm_trimmed=$(cfg_trim_curly_brackets "$1")
+
+  # split into elements along ','
+  declare -a cm_mappings
+  IFS=',' read -r -a cm_mappings <<< "${cm_trimmed}"
+
+  for index in "${!cm_mappings[@]}"
+  do
+    # split mapping into key and value
+    map_key=$(echo ${cm_mappings[index]} | cut -f1 -d':')
+    map_value=$(echo ${cm_mappings[index]} | cut -f2 -d':')
+    # trim spaces and double quotes at start and end
+    tr_key=$(cfg_trim_spaces "${map_key}" | cfg_trim_quotes)
+    tr_value=$(cfg_trim_spaces "${map_value}" | cfg_trim_quotes)
+    cfg_file_map[${tr_key}]=${tr_value}
+  done
+}
+
+function cfg_print_map {
+  for index in "${!cfg_file_map[@]}"
+  do
+    echo "${index} --> ${cfg_file_map[${index}]}"
+  done
+}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,117 @@
+function echo_green() {
+    echo -e "\e[32m$1\e[0m"
+}
+
+function echo_red() {
+    echo -e "\e[31m$1\e[0m"
+}
+
+function echo_yellow() {
+    echo -e "\e[33m$1\e[0m"
+}
+
+ANY_ERROR_EXITCODE=1
+function fatal_error() {
+    echo_red "ERROR: $1" >&2
+    if [[ $# -gt 1 ]]; then
+      exit $2
+    else
+      exit "${ANY_ERROR_EXITCODE}"
+    fi
+}
+
+function check_exit_code {
+    ec=$1
+    ok_msg=$2
+    fail_msg=$3
+
+    if [[ $ec -eq 0 ]]; then
+        echo_green "${ok_msg}"
+    else
+        fatal_error "${fail_msg}"
+    fi
+}
+
+function get_path_for_tool {
+    tool_name=$1
+    tool_envvar_name=$2
+
+    which_out=$(which ${tool_name} 2>&1)
+    exit_code=$?
+    if [[ ${exit_code} -eq 0 ]]; then
+        echo "INFO: found tool ${tool_name} in PATH (${which_out})" >&2
+        echo "${which_out}"
+        return 0
+    fi
+    if [[ -z "${tool_envvar_name}" ]]; then
+        msg="no env var holding the full path to tool '${tool_name}' provided"
+        echo "${msg}" >&2
+        return 1
+    else
+        tool_envvar_value=${!tool_envvar_name}
+        if [[ -x "${tool_envvar_value}" ]]; then
+            msg="INFO: found tool ${tool_envvar_value} via env var ${tool_envvar_name}"
+            echo "${msg}" >&2
+            echo "${tool_envvar_value}"
+            return 0
+        else
+            msg="ERROR: tool '${tool_name}' not in PATH\n"
+            msg+="ERROR: tool '${tool_envvar_value}' via '${tool_envvar_name}' not in PATH"
+            echo "${msg}" >&2
+            echo ""
+            return 2
+        fi
+    fi
+}
+
+function get_host_from_url {
+    url=$1
+    re="(http|https)://([^/:]+)"
+    if [[ $url =~ $re ]]; then
+        echo ${BASH_REMATCH[2]}
+        return 0
+    else
+        echo ""
+        return 1
+    fi
+}
+
+function get_port_from_url {
+    url=$1
+    re="(http|https)://[^:]+:([0-9]+)"
+    if [[ $url =~ $re ]]; then
+        echo ${BASH_REMATCH[2]}
+        return 0
+    else
+        echo ""
+        return 1
+    fi
+}
+
+function get_ipv4_address {
+    hname=$1
+    hipv4=$(grep ${hname} /etc/hosts | grep -v '^[[:space:]]*#' | cut -d ' ' -f 1)
+    # TODO try other methods if the one above does not work --> tool that verifies
+    #      what method can be used?
+    echo "${hipv4}"
+    return 0
+}
+
+# determine container runtime
+function get_container_runtime {
+    apptainer_out=$(which apptainer 2>&1)
+    exit_code=$?
+    if [[ ${exit_code} -eq 0 ]]; then
+        echo "${apptainer_out}"
+        return 0
+    fi
+    singularity_out=$(which singularity 2>&1)
+    exit_code=$?
+    if [[ ${exit_code} -eq 0 ]]; then
+        echo "${singularity_out}"
+        return 0
+    else
+        echo "false"
+        return 1
+    fi
+}


### PR DESCRIPTION
Adding scripts and improving them.

- `bot/build.sh`:
  - use version and repository from `cfg/job.cfg` or default
  - added header, author, license
  - added assumptions
  - added `set -e`
  - source the above helper scripts
  - read `cfg/job.cfg` file
  - set core settings if needed: `HTTP_PROXY`, `HTTPS_PROXY`, `LOCAL_TMP`, `LOAD_MODULES`
  - expand variables in `LOCAL_TMP` into `STORAGE`
  - load modules
  - obtain `cpu_target_arch` from `cfg/job.cfg` setting
  - bump `eessi_version` to `2023.04`
  - calling `install_compatibility_layer.sh`: remove fixed local container, add storage option
- `install_compatibility_layer.sh`:
  - add default version + create job/run-specific `/tmp` + fix id for tgz
  - add arguments for resuming, retaining tmp and more verbose output
  - extended and reformatted usage information
  - source helper script `scripts/utils.sh`
  - add support to resume a previous run given its temporary directory
  - determine container runtime (`singularity` or `apptainer`)
  - define env vars for both `singularity` and `apptainer`
  - `unset PKG_CONFIG_PATH` before running ansible script
  - only tar temporary directory if `--retain-tmp` option is given
  - add message for how to resume a previous run
- `scripts/utils.sh` is borrowed from software-layer. it includes various functions to be used with other scripts in this repo.
- `scripts/cfg_files.sh` is borrowed from software-layer. it provides functions to read a file that contains information about a job.
