### PR TITLE
Add reprod task to Ansible role

### DIFF
--- a/ansible/playbooks/README.md
+++ b/ansible/playbooks/README.md
@@ -55,6 +55,14 @@ Before running the playbook, make sure the following settings are correct, and o
 | reframe_venv | Path where a virtual environment will be created for the ReFrame installation |
 | symlinks_to_host | List of paths that should get a symlink to the corresponding host path |
 
+### Reproducibility settings
+| Variable | Description |
+| --- | --- |
+| prefix_reprod_dir | Name of subdirectory for storing reproducibility information |
+| prefix_packages_file | Filename for storing list of installed packages |
+| prefix_metadata_json | Filename for storing metadata of build |
+
+
 ### Logging
 | Variable | Description |
 | --- | --- |

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -41,6 +41,11 @@ prefix_install: >-
     {{ prefix_use_builtin_bootstrap | ternary('/usr/local/bin/bootstrap-prefix.sh', prefix_custom_bootstrap_script.remote) }}
     {{ prefix_source_options }}
 
+# Reproducibility settings
+prefix_reprod_dir: reprod
+prefix_packages_file: packages.txt
+prefix_metadata_json: build.json
+
 # Logging
 eessi_log_dir: "/tmp/eessi-logs"
 prefix_build_log: "{{ eessi_log_dir }}/prefix-build.log"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/main.yml
@@ -46,3 +46,8 @@
   ansible.builtin.include_tasks: test.yml
   tags:
     - test
+
+- name: Save reproducibility information for this build
+  ansible.builtin.include_tasks: reprod.yml
+  tags:
+    - reprod

--- a/ansible/playbooks/roles/compatibility_layer/tasks/reprod.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/reprod.yml
@@ -1,0 +1,49 @@
+# Store some information and scripts that were used for this installation.
+---
+
+- name: Make a subdirectory for storing build information
+  ansible.builtin.file:
+    path: "{{ gentoo_prefix_path }}/{{ prefix_reprod_dir }}"
+    state: directory
+    mode: '0755'
+  tags:
+    - reprod
+
+- name: Copy the used bootstrap script
+  ansible.builtin.copy:
+    src: "{{ prefix_use_builtin_bootstrap | ternary('/usr/local/bin/bootstrap-prefix.sh', prefix_custom_bootstrap_script.remote) }}"
+    dest: "{{ gentoo_prefix_path }}/{{ prefix_reprod_dir }}/bootstrap-prefix.sh"
+  tags:
+    - reprod
+
+- name: Get list of installed packages
+  ansible.builtin.command: "qlist -IRv"
+  changed_when: false
+  register: qlist
+  tags:
+    - reprod
+
+- name: Dump list of installed packages to a file
+  ansible.builtin.copy:
+    content: "{{ qlist.stdout }}"
+    dest: "{{ gentoo_prefix_path }}/{{ prefix_reprod_dir }}/{{ prefix_packages_file }}"
+  tags:
+    - reprod
+
+- name: Store other metadata of build in a json file
+  ansible.builtin.copy:
+    content: "{{ metadata|to_nice_json }}"
+    dest: "{{ gentoo_prefix_path }}/{{ prefix_reprod_dir }}/{{ prefix_metadata_json }}"
+  vars:
+    metadata:
+      username: "{{ ansible_user_id }}"
+      userid: "{{ ansible_user_uid }}"
+      timestamp: "{{ ansible_date_time.iso8601 }}"
+      hostname: "{{ ansible_hostname }}"
+      host_os: "{{ ansible_distribution }} {{ ansible_distribution_version }}"
+      host_kernel: "{{ ansible_kernel }}"
+      host_memory: "{{ ansible_memory_mb.real }}"
+      host_mounts: "{{ ansible_mounts }}"
+      gentoo_git_commit: "{{ gentoo_git_commit }}"
+  tags:
+    - reprod

--- a/ansible/playbooks/roles/compatibility_layer/tasks/reprod.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/reprod.yml
@@ -13,6 +13,7 @@
   ansible.builtin.copy:
     src: "{{ prefix_use_builtin_bootstrap | ternary('/usr/local/bin/bootstrap-prefix.sh', prefix_custom_bootstrap_script.remote) }}"
     dest: "{{ gentoo_prefix_path }}/{{ prefix_reprod_dir }}/bootstrap-prefix.sh"
+    mode: '0644'
   tags:
     - reprod
 
@@ -27,13 +28,15 @@
   ansible.builtin.copy:
     content: "{{ qlist.stdout }}"
     dest: "{{ gentoo_prefix_path }}/{{ prefix_reprod_dir }}/{{ prefix_packages_file }}"
+    mode: '0644'
   tags:
     - reprod
 
 - name: Store other metadata of build in a json file
   ansible.builtin.copy:
-    content: "{{ metadata|to_nice_json }}"
+    content: "{{ metadata | to_nice_json }}"
     dest: "{{ gentoo_prefix_path }}/{{ prefix_reprod_dir }}/{{ prefix_metadata_json }}"
+    mode: '0644'
   vars:
     metadata:
       username: "{{ ansible_user_id }}"


### PR DESCRIPTION
This created a `reprod` dir in the root of the prefix installation, containing:
- `packages.txt` -> list of installed packages obtained with `qlist -IRv`
- `bootstrap-prefix.sh` -> copy of the used bootstrap script
- `build.json` -> contains (additional) metadata about the build, e.g.:

```
Apptainer> cat /cvmfs/pilot.eessi-hpc.org/versions/2023.04/compat/linux/x86_64/reprod/build.json
{
    "gentoo_git_commit": "29492845e41ea6a0a4a9769c7e0ce287d106079b",
    "host_kernel": "4.18.0-425.10.1.el8_7.x86_64",
    "host_memory": {
        "free": 17278,
        "total": 29912,
        "used": 12634
    },  
    "host_mounts": [
        {
            "block_available": 48574849,
            "block_size": 4096,
            "block_total": 52425979,
            "block_used": 3851130,
            "device": "/dev/xvda1",
            "fstype": "xfs",
            "inode_available": 104345170,
            "inode_total": 104857024,
            "inode_used": 511854,
            "mount": "/usr/share/zoneinfo/Etc/UTC",
            "options": "rw,seclabel,nosuid,nodev,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota,bind",
            "size_available": 198962581504,
            "size_total": 214736809984,
            "uuid": "N/A"
        },  
        {   
            "block_available": 48574849,
            "block_size": 4096,
            "block_total": 52425979,
            "block_used": 3851130,
            "device": "/dev/xvda1",
            "fstype": "xfs",
            "inode_available": 104345170,
            "inode_total": 104857024,
            "inode_used": 511854,
            "mount": "/etc/hosts",
            "options": "rw,seclabel,nosuid,nodev,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota,bind",
            "size_available": 198962581504,
            "size_total": 214736809984,
            "uuid": "N/A"
        },  
        {   
            "block_available": 8796088279786,
            "block_size": 1048576,
            "block_total": 8796093022207,
            "block_used": 4742421,
            "device": "fileserver:/home/bedroge",
            "fstype": "nfs4",
            "inode_available": 0,
            "inode_total": 0,
            "inode_used": 0,
            "mount": "/mnt/shared/home/bedroge",
            "options": "rw,nosuid,nodev,relatime,vers=4.1,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=10.0.52.146,local_lock=none,addr=10.0.99.65",
            "size_available": 9223367064064884736,
            "size_total": 9223372036853727232,
            "uuid": "N/A"
        },  
        {   
            "block_available": 48574849,
            "block_size": 4096,
            "block_total": 52425979,
            "block_used": 3851130,
            "device": "/dev/xvda1",
            "fstype": "xfs",
            "inode_available": 104345170,
            "inode_total": 104857024,
            "inode_used": 511854,
            "mount": "/tmp",
            "options": "rw,seclabel,nosuid,nodev,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota,bind",
            "size_available": 198962581504,
            "size_total": 214736809984,
            "uuid": "N/A"
        },  
        {   
            "block_available": 48574849,
            "block_size": 4096,
            "block_total": 52425979,
            "block_used": 3851130,
            "device": "/dev/xvda1",
            "fstype": "xfs",
            "inode_available": 104345170,
            "inode_total": 104857024,
            "inode_used": 511854,
            "mount": "/var/tmp",
            "options": "rw,seclabel,nosuid,nodev,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota,bind",
            "size_available": 198962581504,
            "size_total": 214736809984,
            "uuid": "N/A"
        },  
        {   
            "block_available": 48574849,
            "block_size": 4096,
            "block_total": 52425979,
            "block_used": 3851130,
            "device": "/dev/xvda1",
            "fstype": "xfs",
            "inode_available": 104345170,
            "inode_total": 104857024,
            "inode_used": 511854,
            "mount": "/cvmfs",
            "options": "rw,seclabel,nosuid,nodev,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota,bind",
            "size_available": 198962581504,
            "size_total": 214736809984,
            "uuid": "N/A"
        }   
    ],
    "host_os": "Debian 11",
    "hostname": "fair-mastodon-c4-4xlarge-0002",
    "timestamp": "2023-04-18T08:29:43Z",
    "userid": 10002,
    "username": "bedroge"
}
```