### PR TITLE
script for updating compat layer 2023.06

### DIFF
--- a/scripts/update-pkgs-EESSI.IO-2023.06_2023-11-15.sh
+++ b/scripts/update-pkgs-EESSI.IO-2023.06_2023-11-15.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -e
+
+mytmpdir=$(mktemp -d)
+
+if [ -z "$EPREFIX" ]; then
+    # this assumes we're running in a Gentoo Prefix environment
+    EPREFIX=$(dirname $(dirname $SHELL))
+fi
+echo "EPREFIX=${EPREFIX}"
+
+# collect list of installed packages before updating packages
+list_installed_pkgs_pre_update=${mytmpdir}/installed-pkgs-pre-update.txt
+echo "Collecting list of installed packages to ${list_installed_pkgs_pre_update}..."
+qlist -IRv | sort | tee ${list_installed_pkgs_pre_update}
+
+# update checkout of gentoo repository to sufficiently recent commit
+# this is required because we pin to a specific commit when bootstrapping the compat layer
+# see gentoo_git_commit in ansible/playbooks/roles/compatibility_layer/defaults/main.yml;
+
+# https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=092c2383f221620534eb948f7f81596d6b8d4a86 (2023-11-15)
+gentoo_commit='092c2383f221620534eb948f7f81596d6b8d4a86'
+echo "Updating $EPREFIX/var/db/repos/gentoo to recent commit (${gentoo_commit})..."
+cd $EPREFIX/var/db/repos/gentoo
+time git fetch origin
+echo "Checking out ${gentoo_commit} in ${PWD}..."
+time git checkout ${gentoo_commit}
+cd -
+
+# update libarchive due to https://glsa.gentoo.org/glsa/202309-14
+emerge --update --oneshot --verbose '=app-arch/libarchive-3.7.1'  # was app-arch/libarchive-3.6.2-r1
+
+# update glibc due to https://glsa.gentoo.org/glsa/202310-03
+emerge --update --oneshot --verbose '=sys-libs/glibc-2.37-r7'  # was sys-libs/glibc-2.37-r3
+
+# update curl due to https://glsa.gentoo.org/glsa/202310-12
+emerge --update --oneshot --verbose '=net-misc/curl-8.3.0-r2'  # was net-misc/curl-8.1.2
+
+# collect list of installed packages after updating packages
+list_installed_pkgs_post_update=${mytmpdir}/installed-pkgs-post-update.txt
+echo "Collecting list of installed packages to ${list_installed_pkgs_post_update}..."
+qlist -IRv | sort | tee ${list_installed_pkgs_post_update}
+
+echo
+echo "diff in installed packages:"
+diff -u ${list_installed_pkgs_pre_update} ${list_installed_pkgs_post_update}
+
+rm -rf ${mytmpdir}


### PR DESCRIPTION
This is a bit WIP. So far, the `emerge` commands have been run for `x86_64` only. The update will be repeated using this script. Then also run for `aarch64` (after verifying that the GLSAs are the same for `aarch64`).

<details><summary>glsa-check output</summary>

```
Checking GLSA 202309-14
>>> The following updates will be performed for this GLSA:
>>> Updates that will be performed:
     app-arch/libarchive-3.7.1 (vulnerable: app-arch/libarchive-3.6.2-r1)


Checking GLSA 202310-03
>>> The following updates will be performed for this GLSA:
>>> Updates that will be performed:
     sys-libs/glibc-2.37-r7 (vulnerable: sys-libs/glibc-2.37-r3)


Checking GLSA 202310-12
>>> The following updates will be performed for this GLSA:
>>> Updates that will be performed:
     net-misc/curl-8.3.0-r2 (vulnerable: net-misc/curl-8.1.2)
```
</details>

<details><summary>diff (pre/post-update) for <code>qlist -IRv | sort</code> for <code>x86_64</code></summary>

```diff
--- upd_cl_x64/x86_64_installed-pkgs-pre-update.txt     2023-11-15 12:10:33.678387653 +0000
+++ upd_cl_x64/x86_64_installed-pkgs-post-update.txt    2023-11-15 12:08:40.414378323 +0000
@@ -32,7 +32,7 @@
 app-alternatives/yacc-1-r2::gentoo
 app-arch/bzip2-1.0.8-r4::gentoo
 app-arch/gzip-1.12-r4::gentoo
-app-arch/libarchive-3.6.2-r1::gentoo
+app-arch/libarchive-3.7.1::gentoo
 app-arch/tar-1.34-r3::gentoo
 app-arch/unzip-6.0_p27-r1::gentoo
 app-arch/xz-utils-5.4.3::gentoo
@@ -209,7 +209,7 @@
 dev-python/trove-classifiers-2023.5.24::gentoo
 dev-python/typing-extensions-4.6.3::gentoo
 dev-python/uc-micro-py-1.0.2::gentoo
-dev-python/uri_template-1.2.0-r1::eessi
+dev-python/uri-template-1.2.0-r1::eessi
 dev-python/webcolors-1.13::gentoo
 dev-python/wheel-0.40.0::gentoo
 dev-python/zipp-3.15.0::gentoo
@@ -234,7 +234,7 @@
 net-libs/libnsl-2.0.0-r1::gentoo
 net-libs/libtirpc-1.3.3::gentoo
 net-libs/nghttp2-1.52.0::gentoo
-net-misc/curl-8.1.2::gentoo
+net-misc/curl-8.3.0-r2::gentoo
 net-misc/rsync-3.2.7-r2::gentoo
 net-misc/wget-1.21.4::gentoo
 perl-core/File-Temp-0.231.100::gentoo
@@ -295,7 +295,7 @@
 sys-kernel/installkernel-gentoo-7::gentoo
 sys-kernel/linux-headers-6.3::gentoo
 sys-libs/gdbm-1.23::gentoo
-sys-libs/glibc-2.37-r3::gentoo
+sys-libs/glibc-2.37-r7::gentoo
 sys-libs/libcap-2.69::gentoo
 sys-libs/libseccomp-2.5.4::gentoo
 sys-libs/libxcrypt-4.4.35::gentoo
```
</details>

<details><summary>diff (pre/post-update) for <code>qlist -IRv | sort</code> for <code>aarch64</code></summary>

```diff
--- upd_cl_x64/aarch64_installed-pkgs-pre-update.txt    2023-11-15 12:10:16.494082798 +0000
+++ upd_cl_x64/aarch64_installed-pkgs-post-update.txt   2023-11-15 12:09:29.335246185 +0000
@@ -32,7 +32,7 @@
 app-alternatives/yacc-1-r2::gentoo
 app-arch/bzip2-1.0.8-r4::gentoo
 app-arch/gzip-1.12-r4::gentoo
-app-arch/libarchive-3.6.2-r1::gentoo
+app-arch/libarchive-3.7.1::gentoo
 app-arch/tar-1.34-r3::gentoo
 app-arch/unzip-6.0_p27-r1::gentoo
 app-arch/xz-utils-5.4.3::gentoo
@@ -209,7 +209,7 @@
 dev-python/trove-classifiers-2023.5.24::gentoo
 dev-python/typing-extensions-4.6.3::gentoo
 dev-python/uc-micro-py-1.0.2::gentoo
-dev-python/uri_template-1.2.0-r1::eessi
+dev-python/uri-template-1.2.0-r1::eessi
 dev-python/webcolors-1.13::gentoo
 dev-python/wheel-0.40.0::gentoo
 dev-python/zipp-3.15.0::gentoo
@@ -234,7 +234,7 @@
 net-libs/libnsl-2.0.0-r1::gentoo
 net-libs/libtirpc-1.3.3::gentoo
 net-libs/nghttp2-1.52.0::gentoo
-net-misc/curl-8.1.2::gentoo
+net-misc/curl-8.3.0-r2::gentoo
 net-misc/rsync-3.2.7-r2::gentoo
 net-misc/wget-1.21.4::gentoo
 perl-core/File-Temp-0.231.100::gentoo
@@ -294,7 +294,7 @@
 sys-kernel/installkernel-gentoo-7::gentoo
 sys-kernel/linux-headers-6.3::gentoo
 sys-libs/gdbm-1.23::gentoo
-sys-libs/glibc-2.37-r3::gentoo
+sys-libs/glibc-2.37-r7::gentoo
 sys-libs/libcap-2.69::gentoo
 sys-libs/libseccomp-2.5.4::gentoo
 sys-libs/libxcrypt-4.4.35::gentoo
</details>