### PR TITLE
Add host symlinks for `/var/log/wtmp` and `/var/run`

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -111,12 +111,16 @@ symlinks_to_host:
   # required if SSSD is used in nsswitch.conf
   - /lib64/libnss_sss.so.2
 
+  # required to make runtime data available for lots of tools (including who and w)
+  - /var/run
+
+  # required by the last command
+  - /var/log/wtmp
+
 #  - /var/lib/munge
 #  - /var/lib/unbound
 #  - /var/lib/VirtualGL
 #  - /var/log/munge
-#  - /var/log/wtmp
-#  - /var/run
 #  - /var/spool
 #  - /var/tmp
 #  - /run/dbus


### PR DESCRIPTION
This should fix the issues with `w` and `who` described in https://gitlab.com/eessi/support/-/issues/32, and also the `last` command.

Without these symlinks:
```
$ source /cvmfs/pilot.eessi-hpc.org/versions/2023.06/init/bash 

[EESSI pilot 2023.06] $ w
 14:16:24 up 3 days, 23:32,  0 users,  load average: 0.00, 0.00, 0.00
USER     TTY        LOGIN@   IDLE   JCPU   PCPU WHAT
[EESSI pilot 2023.06] $ who
[EESSI pilot 2023.06] $ last
last: cannot open /cvmfs/pilot.eessi-hpc.org/versions/2023.06/compat/linux/x86_64/var/log/wtmp: No such file or directory
```

With the host symlinks in place (tested in a non-published transaction on the pilot Stratum 0):
```
[EESSI pilot 2023.06] $ w
 14:17:34 up 3 days, 23:33,  2 users,  load average: 0.00, 0.00, 0.00
USER     TTY        LOGIN@   IDLE   JCPU   PCPU WHAT
bob      pts/0     14:12    1.00s  0.04s  0.00s w
bob      pts/1     14:14    6.00s  0.07s  0.07s -bash
[EESSI pilot 2023.06] $ who
bob      pts/0        2024-01-19 14:12 (<REMOVED ACTUAL IP ADDRESS>)
bob      pts/1        2024-01-19 14:14 (<REMOVED ACTUAL IP ADDRESS>)
[EESSI pilot 2023.06] $ last
bob      pts/1        <REMOVED ACTUAL IP ADDRESS>    Fri Jan 19 14:14   still logged in
bob      pts/0        <REMOVED ACTUAL IP ADDRESS>    Fri Jan 19 14:12   still logged in
bob      pts/1        <REMOVED ACTUAL IP ADDRESS>   Thu Jan 18 16:39 - 18:58  (02:18)
bob      pts/0        <REMOVED ACTUAL IP ADDRESS>   Thu Jan 18 16:37 - 18:58  (02:20)
bob      pts/0        <REMOVED ACTUAL IP ADDRESS>    Mon Jan 15 14:45 - 15:50  (01:05)
reboot   system boot  4.15.0-213-gener Mon Jan 15 14:44   still running
bob      pts/0        <REMOVED ACTUAL IP ADDRESS>    Mon Jan 15 14:34 - 14:43  (00:09)
bob      pts/0        <REMOVED ACTUAL IP ADDRESS>    Tue Jan  2 19:24 - 19:33  (00:09)

wtmp begins Tue Jan  2 19:24:50 2024
```