### PR TITLE
Script for updating `openssl`, `zlib`, `glibc` in `software.eessi.io` version 2023.06

### DIFF
--- a/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
+++ b/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
@@ -19,6 +19,11 @@ qlist -IRv | sort | tee ${list_installed_pkgs_pre_update}
 # this is required because we pin to a specific commit when bootstrapping the compat layer
 # see gentoo_git_commit in ansible/playbooks/roles/compatibility_layer/defaults/main.yml;
 
+# update zlib due to https://security.gentoo.org/glsa/202401-18
+# this has to be done before switching to a newer commit, as that one doesn't have this zlib version anymore,
+# while the current commit does
+emerge --update --oneshot --verbose '=sys-libs/zlib-1.2.13-r2'  # was sys-libs/zlib-1.2.13-r1
+
 # https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=ac78a6d2a0ec2546a59ed98e00499ddd8343b13d (2024-01-31)
 gentoo_commit='ac78a6d2a0ec2546a59ed98e00499ddd8343b13d'
 echo "Updating $EPREFIX/var/db/repos/gentoo to recent commit (${gentoo_commit})..."
@@ -34,9 +39,6 @@ echo '# unmask dev-libs/openssl-1.1.1w (openssl 1.1.x is masked via $EPREFIX/var
 echo '=dev-libs/openssl-1.1.1w' >> ${EPREFIX}/etc/portage/package.unmask
 # update openssl due to https://nvd.nist.gov/vuln/detail/CVE-2023-4807
 emerge --update --oneshot --verbose '=dev-libs/openssl-1.1.1w'  # was dev-libs/openssl-1.1.1u
-
-# update zlib due to https://security.gentoo.org/glsa/202401-18
-emerge --update --oneshot --verbose '=sys-libs/zlib-1.3-r2'  # was sys-libs/zlib-1.2.13-r1
 
 # update glibc due to https://security.gentoo.org/glsa/202402-01
 emerge --update --oneshot --verbose '=sys-libs/glibc-2.37-r10'  # was sys-libs/glibc-2.37-r7

--- a/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
+++ b/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
@@ -25,15 +25,25 @@ echo "Checking out ${eessi_commit} in ${PWD}..."
 time git checkout ${eessi_commit}
 cd -
 
-# update zlib due to https://security.gentoo.org/glsa/202401-18
-# this has to be done before switching to a newer commit of the gentoo repository,
-# as that one doesn't have this zlib version anymore, # while the current commit does
-emerge --update --oneshot --verbose '=sys-libs/zlib-1.2.13-r2'  # was sys-libs/zlib-1.2.13-r1
-
 # update checkout of gentoo repository to sufficiently recent commit
 # this is required because we pin to a specific commit when bootstrapping the compat layer
 # see gentoo_git_commit in ansible/playbooks/roles/compatibility_layer/defaults/main.yml;
+# https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=d9718dafa6ecd841f4364f2ee0039613f0b8efec (2023-10-30)
+gentoo_commit='d9718dafa6ecd841f4364f2ee0039613f0b8efec'
+echo "Updating $EPREFIX/var/db/repos/gentoo to recent commit (${gentoo_commit})..."
+cd $EPREFIX/var/db/repos/gentoo
+time git fetch origin
+echo "Checking out ${gentoo_commit} in ${PWD}..."
+time git checkout ${gentoo_commit}
+cd -
 
+# update zlib due to https://security.gentoo.org/glsa/202401-18
+# this has to be done before switching to an even newer commit of the gentoo repository,
+# as that doesn't have this zlib version anymore, while the current commit does
+emerge --update --oneshot --verbose '=sys-libs/zlib-1.2.13-r2'  # was sys-libs/zlib-1.2.13-r1
+
+# update checkout of gentoo repository to an even more recent commit,
+# which contains the required versions of openssl and glibc
 # https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=ac78a6d2a0ec2546a59ed98e00499ddd8343b13d (2024-01-31)
 gentoo_commit='ac78a6d2a0ec2546a59ed98e00499ddd8343b13d'
 echo "Updating $EPREFIX/var/db/repos/gentoo to recent commit (${gentoo_commit})..."

--- a/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
+++ b/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
@@ -15,14 +15,24 @@ list_installed_pkgs_pre_update=${mytmpdir}/installed-pkgs-pre-update.txt
 echo "Collecting list of installed packages to ${list_installed_pkgs_pre_update}..."
 qlist -IRv | sort | tee ${list_installed_pkgs_pre_update}
 
+# update checkout of eessi overlay to sufficiently recent commit to include fix from https://github.com/EESSI/gentoo-overlay/pull/98
+# https://github.com/EESSI/gentoo-overlay/commit/bf189508bf7510d8acf8ef089d4c7f03f6c512d1 (2024-01-29)
+eessi_commit='bf189508bf7510d8acf8ef089d4c7f03f6c512d1'
+echo "Updating $EPREFIX/var/db/repos/eessi to recent commit (${eessi_commit})..."
+cd $EPREFIX/var/db/repos/eessi
+time git fetch origin
+echo "Checking out ${eessi_commit} in ${PWD}..."
+time git checkout ${eessi_commit}
+cd -
+
+# update zlib due to https://security.gentoo.org/glsa/202401-18
+# this has to be done before switching to a newer commit of the gentoo repository,
+# as that one doesn't have this zlib version anymore, # while the current commit does
+emerge --update --oneshot --verbose '=sys-libs/zlib-1.2.13-r2'  # was sys-libs/zlib-1.2.13-r1
+
 # update checkout of gentoo repository to sufficiently recent commit
 # this is required because we pin to a specific commit when bootstrapping the compat layer
 # see gentoo_git_commit in ansible/playbooks/roles/compatibility_layer/defaults/main.yml;
-
-# update zlib due to https://security.gentoo.org/glsa/202401-18
-# this has to be done before switching to a newer commit, as that one doesn't have this zlib version anymore,
-# while the current commit does
-emerge --update --oneshot --verbose '=sys-libs/zlib-1.2.13-r2'  # was sys-libs/zlib-1.2.13-r1
 
 # https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=ac78a6d2a0ec2546a59ed98e00499ddd8343b13d (2024-01-31)
 gentoo_commit='ac78a6d2a0ec2546a59ed98e00499ddd8343b13d'

--- a/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
+++ b/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
@@ -28,6 +28,13 @@ echo "Checking out ${gentoo_commit} in ${PWD}..."
 time git checkout ${gentoo_commit}
 cd -
 
+# unmask dev-libs/openssl-1.1.1w, so we can update to it
+# (masked by $EPREFIX/var/db/repos/gentoo/profiles/package.mask, because OpenSSL 1.1.x is EOL)
+echo '# unmask dev-libs/openssl-1.1.1w (openssl 1.1.x is masked via $EPREFIX/var/db/repos/gentoo/profiles/package.mask)' >> ${EPREFIX}/etc/portage/package.unmask
+echo '=dev-libs/openssl-1.1.1w' >> ${EPREFIX}/etc/portage/package.unmask
+# update openssl due to https://nvd.nist.gov/vuln/detail/CVE-2023-4807
+emerge --update --oneshot --verbose '=dev-libs/openssl-1.1.1w'  # was dev-libs/openssl-1.1.1u
+
 # update zlib due to https://security.gentoo.org/glsa/202401-18
 emerge --update --oneshot --verbose '=sys-libs/zlib-1.3-r2'  # was sys-libs/zlib-1.2.13-r1
 

--- a/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
+++ b/scripts/update-pkgs-EESSI.IO-2023.06_2024-01-31.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -e
+
+mytmpdir=$(mktemp -d)
+
+if [ -z "$EPREFIX" ]; then
+    # this assumes we're running in a Gentoo Prefix environment
+    EPREFIX=$(dirname $(dirname $SHELL))
+fi
+echo "EPREFIX=${EPREFIX}"
+
+# collect list of installed packages before updating packages
+list_installed_pkgs_pre_update=${mytmpdir}/installed-pkgs-pre-update.txt
+echo "Collecting list of installed packages to ${list_installed_pkgs_pre_update}..."
+qlist -IRv | sort | tee ${list_installed_pkgs_pre_update}
+
+# update checkout of gentoo repository to sufficiently recent commit
+# this is required because we pin to a specific commit when bootstrapping the compat layer
+# see gentoo_git_commit in ansible/playbooks/roles/compatibility_layer/defaults/main.yml;
+
+# https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=ac78a6d2a0ec2546a59ed98e00499ddd8343b13d (2024-01-31)
+gentoo_commit='ac78a6d2a0ec2546a59ed98e00499ddd8343b13d'
+echo "Updating $EPREFIX/var/db/repos/gentoo to recent commit (${gentoo_commit})..."
+cd $EPREFIX/var/db/repos/gentoo
+time git fetch origin
+echo "Checking out ${gentoo_commit} in ${PWD}..."
+time git checkout ${gentoo_commit}
+cd -
+
+# update zlib due to https://security.gentoo.org/glsa/202401-18
+emerge --update --oneshot --verbose '=sys-libs/zlib-1.3-r2'  # was sys-libs/zlib-1.2.13-r1
+
+# update glibc due to https://security.gentoo.org/glsa/202402-01
+emerge --update --oneshot --verbose '=sys-libs/glibc-2.37-r10'  # was sys-libs/glibc-2.37-r7
+
+# collect list of installed packages after updating packages
+list_installed_pkgs_post_update=${mytmpdir}/installed-pkgs-post-update.txt
+echo "Collecting list of installed packages to ${list_installed_pkgs_post_update}..."
+qlist -IRv | sort | tee ${list_installed_pkgs_post_update}
+
+echo
+echo "diff in installed packages:"
+diff -u ${list_installed_pkgs_pre_update} ${list_installed_pkgs_post_update}
+
+rm -rf ${mytmpdir}


### PR DESCRIPTION
This addresses some Gentoo GLSAs and a `openssl` CVE. I'll upload the new tarballs manually.

<details><summary>output of glsa check script</summary>

```
>>> The following updates will be performed for this GLSA:
>>> No upgrade path exists for these packages:
     dev-libs/openssl-1.1.1u


Checking GLSA 202401-18
>>> The following updates will be performed for this GLSA:
>>> Updates that will be performed:
     sys-libs/zlib-1.3-r2 (vulnerable: sys-libs/zlib-1.2.13-r1)


Checking GLSA 202402-01
>>> The following updates will be performed for this GLSA:
>>> Updates that will be performed:
     sys-libs/glibc-2.38-r10 (vulnerable: sys-libs/glibc-2.37-r7)
```

OpenSSL 1.1.x is EOL, and we masked 3.x, which is probably why it doesn't show an upgrade path.

</details>

<details><summary>diff for <code>x86_64</code></summary>

```
 app-text/po4a-0.69::gentoo
 app-text/sgml-common-0.6.3-r7::gentoo
 app-text/xmlto-0.0.28-r10::gentoo
+dev-build/autoconf-2.71-r6::gentoo
+dev-build/autoconf-archive-2023.02.20::gentoo
+dev-build/autoconf-wrapper-20221207-r1::gentoo
+dev-build/automake-1.16.5-r1::gentoo
+dev-build/automake-wrapper-20221207::gentoo
+dev-build/gtk-doc-am-1.33.2::gentoo
+dev-build/libtool-2.4.7-r1::gentoo
+dev-build/make-4.4.1-r1::gentoo
+dev-build/meson-1.1.1::gentoo
+dev-build/meson-format-array-0::gentoo
 dev-db/sqlite-3.42.0::gentoo
 dev-lang/lua-5.1.5-r200::gentoo
 dev-lang/luajit-2.1.0_beta3_p20220613::gentoo
@@ -102,7 +112,7 @@
 dev-libs/mpfr-4.2.0_p9::gentoo
 dev-libs/nettle-3.9.1::gentoo
 dev-libs/npth-1.6-r1::gentoo
-dev-libs/openssl-1.1.1u::gentoo
+dev-libs/openssl-1.1.1w::gentoo
 dev-libs/popt-1.19::gentoo
 dev-lua/lpeg-1.0.2-r101::gentoo
 dev-lua/lua-bit32-5.3.5.1-r1::gentoo
@@ -215,10 +225,7 @@
 dev-python/zipp-3.15.0::gentoo
 dev-util/direnv-2.32.2::eessi
 dev-util/gperf-3.1-r1::gentoo
-dev-util/gtk-doc-am-1.33.2::gentoo
 dev-util/hermes-2.9::gentoo
-dev-util/meson-1.1.1::gentoo
-dev-util/meson-format-array-0::gentoo
 dev-util/patchelf-0.18.0::gentoo
 dev-util/pkgconf-1.8.1::gentoo
 dev-util/re2c-2.2::gentoo
@@ -271,11 +278,6 @@
 sys-auth/passwdqc-2.0.2-r1::gentoo
 sys-cluster/lmod-8.7.23::gentoo
 sys-cluster/rdma-core-45.0::gentoo
-sys-devel/autoconf-2.71-r6::gentoo
-sys-devel/autoconf-archive-2023.02.20::gentoo
-sys-devel/autoconf-wrapper-20221207-r1::gentoo
-sys-devel/automake-1.16.5-r1::gentoo
-sys-devel/automake-wrapper-20221207::gentoo
 sys-devel/bc-1.07.1-r6::gentoo
 sys-devel/binutils-2.40-r5::gentoo
 sys-devel/binutils-config-5.5::gentoo
@@ -285,17 +287,15 @@
 sys-devel/gcc-config-2.11::gentoo
 sys-devel/gettext-0.21.1::gentoo
 sys-devel/gnuconfig-20230121::gentoo
-sys-devel/libtool-2.4.7-r1::gentoo
 sys-devel/m4-1.4.19-r2::gentoo
-sys-devel/make-4.4.1-r1::gentoo
 sys-devel/patch-2.7.6-r5::gentoo
 sys-fabric/opa-psm2-11.2.205::eessi
 sys-fs/e2fsprogs-1.47.0-r1::gentoo
 sys-fs/udev-init-scripts-35::gentoo
-sys-kernel/installkernel-gentoo-7::gentoo
+sys-kernel/installkernel-7::gentoo
 sys-kernel/linux-headers-6.3::gentoo
 sys-libs/gdbm-1.23::gentoo
-sys-libs/glibc-2.37-r7::gentoo
+sys-libs/glibc-2.37-r10::gentoo
 sys-libs/libcap-2.69::gentoo
 sys-libs/libseccomp-2.5.4::gentoo
 sys-libs/libxcrypt-4.4.35::gentoo
@@ -303,7 +303,7 @@
 sys-libs/pam-1.5.3::gentoo
 sys-libs/readline-8.2_p1::gentoo
 sys-libs/timezone-data-2023c::gentoo
-sys-libs/zlib-1.2.13-r1::gentoo
+sys-libs/zlib-1.3-r2::gentoo
 sys-process/numactl-2.0.16::gentoo
 sys-process/procps-3.3.17-r1::gentoo
 sys-process/psmisc-23.6::gentoo
```

</details>


<details><summary>diff for <code>aarch64</code></summary>

```
 app-text/po4a-0.69::gentoo
 app-text/sgml-common-0.6.3-r7::gentoo
 app-text/xmlto-0.0.28-r10::gentoo
+dev-build/autoconf-2.71-r6::gentoo
+dev-build/autoconf-archive-2023.02.20::gentoo
+dev-build/autoconf-wrapper-20221207-r1::gentoo
+dev-build/automake-1.16.5-r1::gentoo
+dev-build/automake-wrapper-20221207::gentoo
+dev-build/gtk-doc-am-1.33.2::gentoo
+dev-build/libtool-2.4.7-r1::gentoo
+dev-build/make-4.4.1-r1::gentoo
+dev-build/meson-1.1.1::gentoo
+dev-build/meson-format-array-0::gentoo
 dev-db/sqlite-3.42.0::gentoo
 dev-lang/lua-5.1.5-r200::gentoo
 dev-lang/luajit-2.1.0_beta3_p20220613::gentoo
@@ -102,7 +112,7 @@
 dev-libs/mpfr-4.2.0_p9::gentoo
 dev-libs/nettle-3.9.1::gentoo
 dev-libs/npth-1.6-r1::gentoo
-dev-libs/openssl-1.1.1u::gentoo
+dev-libs/openssl-1.1.1w::gentoo
 dev-libs/popt-1.19::gentoo
 dev-lua/lpeg-1.0.2-r101::gentoo
 dev-lua/lua-bit32-5.3.5.1-r1::gentoo
@@ -215,10 +225,7 @@
 dev-python/zipp-3.15.0::gentoo
 dev-util/direnv-2.32.2::eessi
 dev-util/gperf-3.1-r1::gentoo
-dev-util/gtk-doc-am-1.33.2::gentoo
 dev-util/hermes-2.9::gentoo
-dev-util/meson-1.1.1::gentoo
-dev-util/meson-format-array-0::gentoo
 dev-util/patchelf-0.18.0::gentoo
 dev-util/pkgconf-1.8.1::gentoo
 dev-util/re2c-2.2::gentoo
@@ -271,11 +278,6 @@
 sys-auth/passwdqc-2.0.2-r1::gentoo
 sys-cluster/lmod-8.7.23::gentoo
 sys-cluster/rdma-core-45.0::gentoo
-sys-devel/autoconf-2.71-r6::gentoo
-sys-devel/autoconf-archive-2023.02.20::gentoo
-sys-devel/autoconf-wrapper-20221207-r1::gentoo
-sys-devel/automake-1.16.5-r1::gentoo
-sys-devel/automake-wrapper-20221207::gentoo
 sys-devel/bc-1.07.1-r6::gentoo
 sys-devel/binutils-2.40-r5::gentoo
 sys-devel/binutils-config-5.5::gentoo
@@ -285,16 +287,14 @@
 sys-devel/gcc-config-2.11::gentoo
 sys-devel/gettext-0.21.1::gentoo
 sys-devel/gnuconfig-20230121::gentoo
-sys-devel/libtool-2.4.7-r1::gentoo
 sys-devel/m4-1.4.19-r2::gentoo
-sys-devel/make-4.4.1-r1::gentoo
 sys-devel/patch-2.7.6-r5::gentoo
 sys-fs/e2fsprogs-1.47.0-r1::gentoo
 sys-fs/udev-init-scripts-35::gentoo
-sys-kernel/installkernel-gentoo-7::gentoo
+sys-kernel/installkernel-7::gentoo
 sys-kernel/linux-headers-6.3::gentoo
 sys-libs/gdbm-1.23::gentoo
-sys-libs/glibc-2.37-r7::gentoo
+sys-libs/glibc-2.37-r10::gentoo
 sys-libs/libcap-2.69::gentoo
 sys-libs/libseccomp-2.5.4::gentoo
 sys-libs/libxcrypt-4.4.35::gentoo
@@ -302,7 +302,7 @@
 sys-libs/pam-1.5.3::gentoo
 sys-libs/readline-8.2_p1::gentoo
 sys-libs/timezone-data-2023c::gentoo
-sys-libs/zlib-1.2.13-r1::gentoo
+sys-libs/zlib-1.3-r2::gentoo
 sys-process/numactl-2.0.16::gentoo
 sys-process/procps-3.3.17-r1::gentoo
 sys-process/psmisc-23.6::gentoo
```
</details>

Looks like some packages were renamed, which is why the diff shows some more packages than expected.