### PR TITLE
Fix ReFrame test step for RISC-V

### DIFF
--- a/Dockerfile.bootstrap-prefix-debian-sid
+++ b/Dockerfile.bootstrap-prefix-debian-sid
@@ -4,7 +4,7 @@ FROM debian:sid-20240211-slim
 COPY bootstrap-prefix.sh /usr/local/bin/bootstrap-prefix.sh
 
 RUN apt-get update
-RUN apt-get install -y gcc g++ make diffutils libgmp-dev perl wget
+RUN apt-get install -y gcc g++ make diffutils libgmp-dev perl wget rustc
 RUN apt-get install -y git python3-pip python3-cryptography python3-venv
 RUN python3 -m venv --system-site-packages /opt/ansible && \
     . /opt/ansible/bin/activate && \

--- a/ansible/playbooks/roles/compatibility_layer/tasks/test.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/test.yml
@@ -30,6 +30,7 @@
   ansible.builtin.command:
     cmd: "{{ reframe_venv_dir + '/bin/' if reframe_exists.rc != 0 else '' }}reframe -r -v -c {{ reframe_venv_dir }}/compat_layer.py"
   environment:
+    EESSI_REPO_DIR: "/cvmfs/{{ cvmfs_repo }}"
     EESSI_VERSION: "{{ eessi_version }}"
     EESSI_OS: "{{ eessi_host_os }}"
     EESSI_ARCH: "{{ eessi_host_arch }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/test.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/test.yml
@@ -32,7 +32,7 @@
   ansible.builtin.command:
     cmd: "{{ reframe_venv_dir + '/bin/' if reframe_exists.rc != 0 else '' }}reframe -r -v -c {{ reframe_venv_dir }}/compat_layer.py"
   environment:
-    EESSI_REPO_DIR: "/cvmfs/{{ cvmfs_repo }}"
+    EESSI_REPO_DIR: "/cvmfs/{{ cvmfs_repository }}"
     EESSI_VERSION: "{{ eessi_version }}"
     EESSI_OS: "{{ eessi_host_os }}"
     EESSI_ARCH: "{{ eessi_host_arch }}"

--- a/ansible/playbooks/roles/compatibility_layer/tasks/test.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/test.yml
@@ -17,6 +17,8 @@
     virtualenv_command: python3 -m venv
     state: forcereinstall
   when: reframe_exists.rc != 0
+  tags:
+    - test
 
 - name: Copy ReFrame test file
   ansible.builtin.copy:

--- a/test/compat_layer.py
+++ b/test/compat_layer.py
@@ -11,6 +11,9 @@ class RunInGentooPrefixTestError(rfm.core.exceptions.ReframeError):
 
 
 class RunInGentooPrefixTest(rfm.RunOnlyRegressionTest):
+    eessi_repo_dir = parameter(
+        os.environ.get('EESSI_REPO_DIR', EESSI_REPO_DIR)
+    )
     eessi_version = parameter(
         os.environ.get('EESSI_VERSION', 'latest').split(',')
     )

--- a/test/compat_layer.py
+++ b/test/compat_layer.py
@@ -30,12 +30,12 @@ class RunInGentooPrefixTest(rfm.RunOnlyRegressionTest):
         self.valid_prog_environs = ['*']
         if self.eessi_version == 'latest':
             # resolve the "latest" symlink to the actual version
-            self.eessi_version = os.readlink(os.path.join(EESSI_REPO_DIR, 'latest'))
+            self.eessi_version = os.readlink(os.path.join(eessi_repo_dir, 'latest'))
         # 2021.06 did not have the 'versions' subdirectory yet
         if self.eessi_version == '2021.06':
-            self.eessi_repo_dir = EESSI_REPO_DIR
+            self.eessi_repo_dir = eessi_repo_dir
         else:
-            self.eessi_repo_dir = os.path.join(EESSI_REPO_DIR, 'versions')
+            self.eessi_repo_dir = os.path.join(eessi_repo_dir, 'versions')
 
         self.compat_dir = os.path.join(
             self.eessi_repo_dir,
@@ -198,7 +198,7 @@ class SymlinksToHostFilesTest(RunInGentooPrefixTest):
             sn.assert_found(f'\n/{self.symlink_to_host}\n', self.stdout),
         ])
 
-        
+
 @rfm.simple_test
 class GentooOverlayGitTest(RunInGentooPrefixTest):
     def __init__(self):
@@ -217,7 +217,7 @@ class GentooOverlayGitTest(RunInGentooPrefixTest):
 
         self.sanity_patterns = sn.assert_found(gentoo_git_repo_info, self.stdout)
 
-        
+
 @rfm.simple_test
 class GlibcEnvFileTest(RunInGentooPrefixTest):
     def __init__(self):
@@ -229,7 +229,7 @@ class GlibcEnvFileTest(RunInGentooPrefixTest):
         self.command = 'equery has --package glibc EXTRA_EMAKE'
 
         trusted_dir = os.path.join(
-            EESSI_REPO_DIR,
+            eessi_repo_dir,
             'host_injections',
             self.eessi_version,
             'compat',


### PR DESCRIPTION
I ran into an issue with `maturin` not being available as a prebuilt wheel, and building from source requires `rustc`, so this PR adds it to the Debian Sid container.

Furthermore, the path to the CVMFS repo was hardcoded to `/cvmfs/software.eessi.io`, so I've also added some option to override that.

Finally, one step in the test task was missing the `test` tag, which means that the step was skipped if the playbook was run with `-t test`.

These changes allowed me to run the test suite:
```
Perform task: TASK: compatibility_layer : Run ReFrame tests (N)o/(y)es/(c)ontinue: *************************************************************************************************************************

TASK [compatibility_layer : Run ReFrame tests] *************************************************************************************************************************************************************
ok: [localhost]
```