### PR TITLE
Bump build container's base image to Debian Sid 20240330

### DIFF
--- a/Dockerfile.bootstrap-prefix-debian-sid
+++ b/Dockerfile.bootstrap-prefix-debian-sid
@@ -1,5 +1,5 @@
 # Should move to Trixie whenever riscv64 images are available
-FROM debian:sid-20240211-slim
+FROM debian:sid-20240330-slim
 
 COPY bootstrap-prefix.sh /usr/local/bin/bootstrap-prefix.sh
 


### PR DESCRIPTION
This is to get rid of the vulnerable XZ version in our build container.

The existing image has:
```
xz (XZ Utils) 5.6.0
```

The new one will have version `5.6.1+really5.4.5-1`:
```
xz (XZ Utils) 5.4.5
```