### PR TITLE
Fix order of commands in installation script for `sssd` and `nss-pam-ldapd`

### DIFF
--- a/scripts/install-sssd-and-nss-pam-ldapd-EESSI.IO-2023.06_2024-04-15.sh
+++ b/scripts/install-sssd-and-nss-pam-ldapd-EESSI.IO-2023.06_2024-04-15.sh
@@ -27,6 +27,15 @@ echo "Checking out ${eessi_commit} in ${PWD}..."
 time git checkout ${eessi_commit}
 cd -
 
+# remove the host symlinks that are no longer needed
+# see: https://github.com/EESSI/compatibility-layer/pull/199
+rm ${EPREFIX}/etc/nsswitch.conf
+rm ${EPREFIX}/lib64/libnss_ldap.so.2
+rm ${EPREFIX}/lib64/libnss_sss.so.2
+rm ${EPREFIX}/var/run
+# the following symlink is in our playbook, but it hadn't been added to the production repository yet
+# rm ${EPREFIX}/var/log/wtmp
+
 # reinstall the currently installed version of glibc to apply the changes from https://github.com/EESSI/gentoo-overlay/pull/99
 emerge --verbose =$(qlist -IRv sys-libs/glibc)
 
@@ -47,15 +56,6 @@ sys-auth/sssd -daemon -man
 EOF
 emerge --verbose sys-auth/nss-pam-ldapd::eessi
 emerge --verbose sys-auth/sssd::eessi
-
-# remove the host symlinks that are no longer needed
-# see: https://github.com/EESSI/compatibility-layer/pull/199
-rm ${EPREFIX}/etc/nsswitch.conf
-rm ${EPREFIX}/lib64/libnss_ldap.so.2
-rm ${EPREFIX}/lib64/libnss_sss.so.2
-rm ${EPREFIX}/var/run
-# the following symlink is in our playbook, but it hadn't been added to the production repository yet
-# rm ${EPREFIX}/var/log/wtmp
 
 # collect list of installed packages after updating packages
 list_installed_pkgs_post_update=${mytmpdir}/installed-pkgs-post-update.txt


### PR DESCRIPTION
There was a stupid mistake in #199, which first reinstalled new packages and then removed symlinks. But those new packages actually provided files that replace the symlinks, so the files themselves got removed again later on :man_facepalming:. I fixed the order in the script, and it now first removes the symlinks.

Fixed it in the repo by manually copying the missing files to the Stratum 0, and adding them in a transaction:
```
[mod] /cvmfs/software.eessi.io/versions
[mod] /cvmfs/software.eessi.io/versions/2023.06
[mod] /cvmfs/software.eessi.io/versions/2023.06/compat
[mod] /cvmfs/software.eessi.io/versions/2023.06/compat/linux
[mod] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64
[mod] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib64
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib64/libnss_ldap.so.2
[rem] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib64/libnss_sss.so
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib64/libnss_sss.so
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib64/libnss_sss.so.2
[rem] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib64/libnss_sss.so.2.0.0
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/lib64/libnss_sss.so.2.0.0
[mod] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64
[mod] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64/lib64
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64/lib64/libnss_ldap.so.2
[rem] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64/lib64/libnss_sss.so
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64/lib64/libnss_sss.so
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64/lib64/libnss_sss.so.2
[rem] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64/lib64/libnss_sss.so.2.0.0
[add] /cvmfs/software.eessi.io/versions/2023.06/compat/linux/aarch64/lib64/libnss_sss.so.2.0.0
```