### PR TITLE
Add ReFrame test that runs `pip check` and modify the `ld.gold` check

### DIFF
--- a/test/compat_layer.py
+++ b/test/compat_layer.py
@@ -233,3 +233,15 @@ class GlibcEnvFileTest(RunInGentooPrefixTest):
             f'user-defined-trusted-dirs={trusted_dir}',
             self.stdout
         )
+
+
+@rfm.simple_test
+class PipCheckTest(RunInGentooPrefixTest):
+    def __init__(self):
+        super().__init__()
+        self.descr = 'Verify that "pip check" does not return any errors.'
+        self.command = 'pip check'
+        self.sanity_patterns = sn.all([
+            sn.assert_eq(self.exit_code, 0),
+            sn.assert_found('\nNo broken requirements found.\n', self.stdout),
+        ])

--- a/test/compat_layer.py
+++ b/test/compat_layer.py
@@ -63,11 +63,13 @@ class EchoTest(RunInGentooPrefixTest):
 
 @rfm.simple_test
 class ToolsAvailableTest(RunInGentooPrefixTest):
-    tool = parameter(['archspec', 'emerge', 'equery', 'ld.gold', 'make', 'patch', 'patchelf'])
+    tool = parameter(['archspec', 'emerge', 'equery', 'ld.bfd', 'ld.gold', 'make', 'patch', 'patchelf'])
 
     def __init__(self):
         # patchelf is only installed since 2021.06 compat layer
         self.skip_if(self.tool == 'patchelf' and self.eessi_version == '2021.03')
+        # 2023.06 still had both ld.bfd and ld.gold, but the latter will not be included in future versions
+        self.skip_if(self.tool == 'ld.gold' and self.eessi_version != '2023.06')
         super().__init__()
         self.descr = 'Verify that some required tools are available'
         self.command = f'which {self.tool}'


### PR DESCRIPTION
Closes #144. Note that we have to skip the test for a new version if we decide to drop `pip` from our compat layer, see  https://github.com/EESSI/gentoo-overlay/issues/83.

As we (most likely) won't have `ld.gold` in future versions, and 2023.06 has both `ld.bfd` and `ld.gold`, I've adapted the corresponding check as a preparation for a new EESSI version.


Tested on the 2023.06 stack:
```
[  PASSED  ] Ran 24/24 test case(s) from 24 check(s) (0 failure(s), 0 skipped, 0 aborted)
[==========] Finished on Mon Jan  6 11:17:56 2025+0100
```
