### PR TITLE
Let Ansible configure custom overlays

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
+++ b/ansible/playbooks/roles/compatibility_layer/tasks/add_overlay.yml
@@ -5,26 +5,17 @@
     cmd: emerge gentoolkit
     creates: "{{ gentoo_prefix_path }}/usr/bin/equery"
 
-- name: Install eselect-repository
-  community.general.portage:
-    package: eselect-repository
-    state: present
-
 # We need git in order to add Gentoo overlays hosted on git repositories.
 - name: Install git
   community.general.portage:
     package: dev-vcs/git
     state: present
 
-- name: Check which repositories have been installed
-  ansible.builtin.command: eselect repository list -i
-  register: repositories_installed
-  changed_when: false
-
-- name: Add custom overlay configuration
-  ansible.builtin.command:
-    cmd: "eselect repository add {{ item.name }} {{ item.source }} {{ item.url }}"
-  when: item.name not in repositories_installed.stdout
+- name: Add configuration files for custom overlays
+  ansible.builtin.template:
+    src: overlay.conf.j2
+    dest: "{{ gentoo_prefix_path }}/etc/portage/repos.conf/{{ item.name }}.conf"
+    mode: "0644"
   loop: "{{ custom_overlays }}"
 
 - name: Make configuration file with overlays that can override eclasses

--- a/ansible/playbooks/roles/compatibility_layer/templates/overlay.conf.j2
+++ b/ansible/playbooks/roles/compatibility_layer/templates/overlay.conf.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+[{{ item.name }}]
+location = {{ gentoo_prefix_path }}/var/db/repos/{{ item.name }}
+sync-type = {{ item.source }}
+sync-uri = {{ item.url }}
+{% if item.branch is defined %}
+sync-git-clone-extra-opts = --branch {{ item.branch }}
+{% endif %}


### PR DESCRIPTION
This does the same thing (adding a configuration file to `$EPREFIX/etc/portage/repos.conf/` for every custom overlay) with Ansible, which means we no longer need to rely on running an `eselect repository add` command. Besides making things a bit cleaner, it also has the advantage that we can use specific branches. The latter is useful for testing new compat layer installations: you don't need to merge the new package set first (see https://github.com/EESSI/compatibility-layer/pull/209, which worked without having https://github.com/EESSI/gentoo-overlay/pull/108 merged).