### PR TITLE
Remove `hermes` package at the end of the compat layer installation

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -80,6 +80,7 @@ prefix_remove_packages:
   - dev-lang/rust-bin
   - dev-python/setuptools-rust
   - dev-util/cmake
+  - dev-util/hermes
   - dev-util/ninja
   - virtual/rust
 


### PR DESCRIPTION
Closes #190.

Hermes (https://github.com/TACC/Hermes) is only needed for running the Lmod post-installation tests, it can be safely removed afterwards.