### PR TITLE
Update trusted directories for glibc to leverage variable symlinks

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -62,7 +62,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif

--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -20,9 +20,9 @@ gentoo_git_repo: https://github.com/gentoo/gentoo.git
 gentoo_git_commit: 083e38cef302128d595e9f9cfd029ad8f67ec2b7
 prefix_required_space: 15 GB
 prefix_user_defined_trusted_dirs:
-  - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib/override"
-  - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib/nvidia"
-  - "/cvmfs/{{ cvmfs_repository }}/host_injections/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib/amd"
+  - "/cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib/override"
+  - "/cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib/nvidia"
+  - "/cvmfs/{{ cvmfs_repository }}/versions/{{ eessi_version }}/compat/{{ eessi_host_os }}/{{ eessi_host_arch }}/lib/amd"
 prefix_mask_packages: |
   # stick to GCC 13.x; using a too recent compiler in the compat layer may complicate stuff in the software layer,
   # see for example https://github.com/EESSI/software-layer/issues/151


### PR DESCRIPTION
Fixes #226 

Requires that these directories become variable symlinks.

Since this is pretty relevant to security, I am inclined to point these variable symlinks to `/dev/null` by default but that does not actually address the problem being discussed in #226 (having to harass the admins to link the CUDA drivers). If we can have logic in our CVMFS configuration then maybe we can address that.
