### PR TITLE
add installation options for sys-cluster/modules pkg

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
+++ b/ansible/playbooks/roles/compatibility_layer/defaults/main.yml
@@ -37,6 +37,9 @@ prefix_bootstrap_use_flags: |
   # only install Python 3.13
   */* PYTHON_TARGETS: -* python3_13
   */* PYTHON_SINGLE_TARGET: -* python3_13
+  # Modules: disable installation of man pages and shell setup files to be able
+  # to also install Lmod. enable *conflict unload* and *require via* features.
+  sys-cluster/modules -shell-setup -man-install +new-features
 prefix_use_builtin_bootstrap: false
 prefix_custom_bootstrap_script:
   local: "{{ playbook_dir }}/../../bootstrap-prefix.sh"


### PR DESCRIPTION
* Disable "shell-setup" and "man-install" uses to be able to install both Modules and Lmod tools

* Enable "new-features" use to get the *conflict unload* and *require via* features

This is linked with the addition of sys-cluster/modules package in gentoo-overlay. See EESSI/gentoo-overlay#119.