### PR TITLE
Use container images based on software layer's build node images

### DIFF
--- a/.github/workflows/build-and-publish-build-node-container.yml
+++ b/.github/workflows/build-and-publish-build-node-container.yml
@@ -1,0 +1,61 @@
+name: Build and publish EESSI Docker image used for building the compatibility layer
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Dockerfile.build-node-compat-layer-*
+      - bootstrap-prefix.sh
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Dockerfile.build-node-compat-layer-*
+      - bootstrap-prefix.sh
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  build_and_publish:
+    name: Build and publish image
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - os: 'debian-12'
+            platform: 'amd64, arm64'
+          - os: 'debian-13'
+            platform: 'amd64, arm64, riscv64'
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Convert and store repository owner in lowercase
+        run: |
+          echo "REPOSITORY_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Build and push to GitHub Packages
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          tags: ghcr.io/${{ env.REPOSITORY_OWNER }}/build-node-compat-layer:${{ matrix.os }}
+          file: Dockerfile.build-node-compat-layer-${{ matrix.os }}
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile.build-node-compat-layer-debian-12
+++ b/Dockerfile.build-node-compat-layer-debian-12
@@ -1,0 +1,21 @@
+FROM ghcr.io/eessi/build-node:debian12
+
+COPY bootstrap-prefix.sh /usr/local/bin/bootstrap-prefix.sh
+
+RUN apt-get update
+RUN apt-get install -y gcc g++ make diffutils libgmp-dev perl wget
+RUN apt-get install -y git python3-pip python3-cryptography python3-venv
+RUN python3 -m venv --system-site-packages /opt/ansible && \
+    . /opt/ansible/bin/activate && \
+    pip3 install --upgrade pip && \
+    pip3 install ansible && \
+    ln -s /opt/ansible/bin/ansible* /usr/local/bin/ && \
+    deactivate
+RUN chmod 755 /usr/local/bin/bootstrap-prefix.sh
+
+ENV LC_ALL=C.UTF-8
+ENV PATH=/usr/local/bin:$PATH
+
+RUN groupadd -g 1001 portage && useradd -ms /bin/bash -u 1001 -g portage portage
+
+ENTRYPOINT ["/usr/local/bin/bootstrap-prefix.sh"]

--- a/Dockerfile.build-node-compat-layer-debian-13
+++ b/Dockerfile.build-node-compat-layer-debian-13
@@ -1,0 +1,21 @@
+FROM ghcr.io/eessi/build-node:debian13
+
+COPY bootstrap-prefix.sh /usr/local/bin/bootstrap-prefix.sh
+
+RUN apt-get update
+RUN apt-get install -y gcc g++ make diffutils libgmp-dev perl wget rustc
+RUN apt-get install -y git python3-pip python3-cryptography python3-venv
+RUN python3 -m venv --system-site-packages /opt/ansible && \
+    . /opt/ansible/bin/activate && \
+    pip3 install --upgrade pip && \
+    pip3 install ansible && \
+    ln -s /opt/ansible/bin/ansible* /usr/local/bin/ && \
+    deactivate
+RUN chmod 755 /usr/local/bin/bootstrap-prefix.sh
+
+ENV LC_ALL=C.UTF-8
+ENV PATH=/usr/local/bin:$PATH
+
+RUN groupadd -g 1001 portage && useradd -ms /bin/bash -u 1001 -g portage portage
+
+ENTRYPOINT ["/usr/local/bin/bootstrap-prefix.sh"]


### PR DESCRIPTION
This adds new container images that are based on the ones that we used for the software layer, and install some additional tools on top (e.g. Ansible). This allows us to also use `eessi_container.sh`, and make it easier to update compat layers by using fuse mounts and overlays.

For now I've left the old dockerfiles and the old CI workflow in place until we've tested this a bit more.