### PR TITLE
rename `dev-util/{cmake,ninja}` to `dev-build/{cmake,ninja}` + also remove `dev-build/meson`

### DIFF
--- a/ansible/playbooks/roles/compatibility_layer/vars/2026.06.yml
+++ b/ansible/playbooks/roles/compatibility_layer/vars/2026.06.yml
@@ -101,9 +101,9 @@ prefix_remove_packages:
     - dev-lang/rust
     - dev-lang/rust-bin
     - dev-python/setuptools-rust
-    - dev-util/cmake
+    - dev-build/cmake
+    - dev-build/ninja
     - dev-util/hermes
-    - dev-util/ninja
     - virtual/rust
 
 # version of ReFrame to use for running the tests

--- a/ansible/playbooks/roles/compatibility_layer/vars/2026.06.yml
+++ b/ansible/playbooks/roles/compatibility_layer/vars/2026.06.yml
@@ -102,6 +102,7 @@ prefix_remove_packages:
     - dev-lang/rust-bin
     - dev-python/setuptools-rust
     - dev-build/cmake
+    - dev-build/meson
     - dev-build/ninja
     - dev-util/hermes
     - virtual/rust


### PR DESCRIPTION
Fixes #236.

The current 2026.06 installations do have these tools, so we may want to trigger a rebuild here to get them removed?

Edit: also added meson to the list.